### PR TITLE
fix(agent): save title rename on blur

### DIFF
--- a/src/presentation/app-shell/AgentConsoleActions.tsx
+++ b/src/presentation/app-shell/AgentConsoleActions.tsx
@@ -112,8 +112,7 @@ export function AgentConsoleActions({
     }
   }, [mode])
 
-  const submitRename = async (event: FormEvent): Promise<void> => {
-    event.preventDefault()
+  const commitRename = async (): Promise<void> => {
     const normalizedName = name.trim()
     if (!normalizedName || isSubmitting) return
     setIsSubmitting(true)
@@ -123,6 +122,10 @@ export function AgentConsoleActions({
     } finally {
       setIsSubmitting(false)
     }
+  }
+  const submitRename = (event: FormEvent): void => {
+    event.preventDefault()
+    void commitRename()
   }
   const removeAgent = async (): Promise<void> => {
     if (isSubmitting) return
@@ -152,15 +155,18 @@ export function AgentConsoleActions({
       <div className="agent-console-actions__start">
         {identityControl}
         {mode === 'rename' ? (
-          <form
-            className="agent-console-actions__editor nodrag"
-            onSubmit={(event) => void submitRename(event)}
-          >
+          <form className="agent-console-actions__editor nodrag" onSubmit={submitRename}>
             <input
               aria-label={t('agent.name')}
               autoFocus
               value={name}
-              onBlur={cancelRename}
+              onBlur={() => {
+                if (name.trim()) {
+                  void commitRename()
+                } else {
+                  cancelRename()
+                }
+              }}
               onChange={(event) => setName(event.target.value)}
               onFocus={(event) => event.currentTarget.select()}
               onKeyDown={handleEditorKeyDown}

--- a/tests/unit/presentation/agent-console-actions.spec.tsx
+++ b/tests/unit/presentation/agent-console-actions.spec.tsx
@@ -54,6 +54,32 @@ describe('Agent console actions', () => {
     expect(screen.getByRole('textbox', { name: 'Agent 名称' })).toHaveFocus()
   })
 
+  it('commits a normalized inline rename when the editor loses focus', async () => {
+    const onRename = vi.fn(async () => undefined)
+    render(<AgentConsoleActions agent={agent} onRemove={vi.fn()} onRename={onRename} />)
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'Agent 2，双击重命名' }))
+    const input = screen.getByRole('textbox', { name: 'Agent 名称' })
+    fireEvent.change(input, { target: { value: '  实现 Agent  ' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith(agent, '实现 Agent'))
+    expect(onRename).toHaveBeenCalledOnce()
+  })
+
+  it('treats Escape as an explicit cancellation of inline rename', () => {
+    const onRename = vi.fn(async () => undefined)
+    render(<AgentConsoleActions agent={agent} onRemove={vi.fn()} onRename={onRename} />)
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'Agent 2，双击重命名' }))
+    const input = screen.getByRole('textbox', { name: 'Agent 名称' })
+    fireEvent.change(input, { target: { value: '不保存的名称' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByRole('textbox', { name: 'Agent 名称' })).not.toBeInTheDocument()
+    expect(onRename).not.toHaveBeenCalled()
+  })
+
   it('supports roving keyboard focus in the action menu', () => {
     render(<AgentConsoleActions agent={agent} onRemove={vi.fn()} onRename={vi.fn()} />)
     const trigger = screen.getByRole('button', { name: 'Agent 2 更多操作' })


### PR DESCRIPTION
## Summary
- save Agent title edits when the inline editor loses focus
- preserve Escape as explicit cancellation and normalize submitted names
- add regression coverage for blur submission and cancellation

## Testing
- pnpm pre-commit
- targeted real Electron rename diagnostic