### PR TITLE
fix(ci): use bash for packaged smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,10 @@ jobs:
 
       - name: Run packaged terminal smoke test
         if: runner.os != 'Linux'
+        shell: bash
         env:
           CLEANCODE_E2E_PREBUILT: '1'
-        run: |
-          pnpm test:e2e \
-            tests/e2e/run-terminal-sessions.e2e.spec.ts \
-            -t "runs shell commands from the active project workspace"
+        run: pnpm test:e2e tests/e2e/run-terminal-sessions.e2e.spec.ts -t "runs shell commands from the active project workspace"
 
       - run: pnpm ${{ matrix.dist_script }}
 


### PR DESCRIPTION
## Summary

- run the non-Linux packaged smoke test with an explicit Bash shell
- keep the Vitest file filter and test-name filter in one command so Windows PowerShell cannot split `-t` into a separate command

## Root cause

The `v0.1.0` Preview run used PowerShell on Windows, where backslash is not a line-continuation character. The full E2E suite passed, then PowerShell treated `-t` as an independent command and failed the job.

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/release.yml`
- `pnpm pre-commit`
  - 1100 unit tests passed
  - 160 integration tests passed, 3 skipped
  - 76 contract tests passed
  - 34 E2E tests passed