### PR TITLE
fix(packaging): include Windows ConPTY runtime

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: Build Electron / ${{ matrix.id }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +58,43 @@ jobs:
           done
           exit 1
       - run: pnpm exec electron-vite build
+      - name: Package Windows application
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          pnpm prepare:packaging
+          pnpm exec electron-builder --dir --win --x64 --publish never
+      - name: Resolve packaged Windows executable
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          packaged_relative_path=$(find release \
+            -path '*unpacked/CleanCode.exe' \
+            -type f -print -quit)
+
+          if [ -z "$packaged_relative_path" ]; then
+            echo "Packaged Windows executable was not found." >&2
+            exit 1
+          fi
+
+          packaged_executable_path=$(node -e \
+            "process.stdout.write(require('node:path').resolve(process.argv[1]))" \
+            "$packaged_relative_path")
+          echo "CLEANCODE_E2E_EXECUTABLE_PATH=$packaged_executable_path" >> "$GITHUB_ENV"
+      - name: Run packaged Windows terminal smoke test
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          CLEANCODE_E2E_PREBUILT: '1'
+        run: pnpm test:e2e tests/e2e/run-terminal-sessions.e2e.spec.ts -t "runs shell commands from the active project workspace"
+      - name: Upload packaged Windows smoke diagnostics
+        if: failure() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: ignore
+          name: electron-e2e-packaged-diagnostics-windows
+          path: test-results/e2e
+          retention-days: 7
       - name: Package Electron binary
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,15 @@ jobs:
           CLEANCODE_E2E_PREBUILT: '1'
         run: pnpm test:e2e tests/e2e/run-terminal-sessions.e2e.spec.ts -t "runs shell commands from the active project workspace"
 
+      - name: Upload packaged smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: ignore
+          name: CleanCode-preview-diagnostics-${{ matrix.id }}-${{ github.run_id }}
+          path: test-results/e2e
+          retention-days: 7
+
       - run: pnpm ${{ matrix.dist_script }}
 
       - uses: actions/upload-artifact@v7

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -4,6 +4,8 @@ artifactName: ${productName}-${version}-${os}-${arch}.${ext}
 directories:
   output: release
 
+afterPack: ./scripts/after-pack.mjs
+
 files:
   - out/**/*
 

--- a/scripts/after-pack.d.mts
+++ b/scripts/after-pack.d.mts
@@ -1,0 +1,10 @@
+export interface AfterPackContext {
+  readonly appOutDir: string
+  readonly arch: number
+  readonly electronPlatformName: string
+  readonly packager: {
+    readonly projectDir: string
+  }
+}
+
+export default function afterPack(context: AfterPackContext): Promise<void>

--- a/scripts/after-pack.mjs
+++ b/scripts/after-pack.mjs
@@ -1,0 +1,67 @@
+import { constants } from 'node:fs'
+import { access, copyFile, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const electronBuilderArchitectureNames = new Map([
+  [1, 'x64'],
+  [3, 'arm64']
+])
+const conptyRuntimeFiles = ['conpty.dll', 'OpenConsole.exe']
+
+export default async function afterPack(context) {
+  if (context.electronPlatformName !== 'win32') return
+
+  const architecture = electronBuilderArchitectureNames.get(context.arch)
+  if (!architecture) {
+    throw new Error(`Unsupported Windows node-pty packaging architecture: ${context.arch}`)
+  }
+
+  const sourceDirectory = join(
+    context.packager.projectDir,
+    'node_modules',
+    'node-pty',
+    'prebuilds',
+    `win32-${architecture}`,
+    'conpty'
+  )
+  const packagedNodePtyDirectory = join(
+    context.appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    'node-pty'
+  )
+  const nativeModuleDirectory = await findPackagedConptyNativeModuleDirectory(
+    packagedNodePtyDirectory,
+    architecture
+  )
+  const destinationDirectory = join(nativeModuleDirectory, 'conpty')
+
+  await mkdir(destinationDirectory, { recursive: true })
+  await Promise.all(
+    conptyRuntimeFiles.map((fileName) =>
+      copyFile(join(sourceDirectory, fileName), join(destinationDirectory, fileName))
+    )
+  )
+}
+
+async function findPackagedConptyNativeModuleDirectory(nodePtyDirectory, architecture) {
+  const candidates = [
+    join(nodePtyDirectory, 'build', 'Release'),
+    join(nodePtyDirectory, 'build', 'Debug'),
+    join(nodePtyDirectory, 'prebuilds', `win32-${architecture}`)
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      await access(join(candidate, 'conpty.node'), constants.R_OK)
+      return candidate
+    } catch {
+      // Continue in node-pty's native module load order.
+    }
+  }
+
+  throw new Error(
+    `Packaged node-pty conpty.node was not found for Windows ${architecture}: ${candidates.join(', ')}`
+  )
+}

--- a/tests/unit/support/windows-node-pty-packaging.spec.ts
+++ b/tests/unit/support/windows-node-pty-packaging.spec.ts
@@ -1,0 +1,146 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import afterPack from '../../../scripts/after-pack.mjs'
+
+describe('Windows node-pty packaging', () => {
+  it.each([
+    { arch: 1, architecture: 'x64' },
+    { arch: 3, architecture: 'arm64' }
+  ])(
+    'places the bundled ConPTY runtime beside the rebuilt $architecture native module',
+    async ({ arch, architecture }) => {
+      const fixture = await createPackagingFixture(architecture)
+      const nativeModuleDirectory = join(
+        fixture.appOutDir,
+        'resources',
+        'app.asar.unpacked',
+        'node_modules',
+        'node-pty',
+        'build',
+        'Release'
+      )
+
+      try {
+        await writeFixtureFile(nativeModuleDirectory, 'conpty.node', 'rebuilt native module')
+
+        await afterPack({
+          appOutDir: fixture.appOutDir,
+          arch,
+          electronPlatformName: 'win32',
+          packager: { projectDir: fixture.projectDirectory }
+        })
+
+        await expect(
+          readFile(join(nativeModuleDirectory, 'conpty', 'conpty.dll'), 'utf8')
+        ).resolves.toBe(`${architecture} conpty`)
+        await expect(
+          readFile(join(nativeModuleDirectory, 'conpty', 'OpenConsole.exe'), 'utf8')
+        ).resolves.toBe(`${architecture} console`)
+      } finally {
+        await fixture.cleanup()
+      }
+    }
+  )
+
+  it('uses the packaged prebuild when electron-builder does not produce a rebuilt module', async () => {
+    const fixture = await createPackagingFixture('x64')
+    const nativeModuleDirectory = join(
+      fixture.appOutDir,
+      'resources',
+      'app.asar.unpacked',
+      'node_modules',
+      'node-pty',
+      'prebuilds',
+      'win32-x64'
+    )
+
+    try {
+      await writeFixtureFile(nativeModuleDirectory, 'conpty.node', 'prebuilt native module')
+
+      await afterPack({
+        appOutDir: fixture.appOutDir,
+        arch: 1,
+        electronPlatformName: 'win32',
+        packager: { projectDir: fixture.projectDirectory }
+      })
+
+      await expect(
+        readFile(join(nativeModuleDirectory, 'conpty', 'conpty.dll'), 'utf8')
+      ).resolves.toBe('x64 conpty')
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  it('fails packaging when no loadable Windows ConPTY native module was packaged', async () => {
+    const fixture = await createPackagingFixture('x64')
+
+    try {
+      await expect(
+        afterPack({
+          appOutDir: fixture.appOutDir,
+          arch: 1,
+          electronPlatformName: 'win32',
+          packager: { projectDir: fixture.projectDirectory }
+        })
+      ).rejects.toThrow('Packaged node-pty conpty.node was not found')
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  it('leaves non-Windows packages unchanged', async () => {
+    const fixture = await createPackagingFixture('x64')
+
+    try {
+      await expect(
+        afterPack({
+          appOutDir: fixture.appOutDir,
+          arch: 1,
+          electronPlatformName: 'darwin',
+          packager: { projectDir: fixture.projectDirectory }
+        })
+      ).resolves.toBeUndefined()
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+})
+
+async function createPackagingFixture(architecture: string): Promise<{
+  readonly appOutDir: string
+  readonly cleanup: () => Promise<void>
+  readonly projectDirectory: string
+}> {
+  const directory = await mkdtemp(join(tmpdir(), 'cleancode-node-pty-packaging-'))
+  const projectDirectory = join(directory, 'project')
+  const appOutDir = join(directory, 'win-unpacked')
+  const sourceDirectory = join(
+    projectDirectory,
+    'node_modules',
+    'node-pty',
+    'prebuilds',
+    `win32-${architecture}`,
+    'conpty'
+  )
+
+  await writeFixtureFile(sourceDirectory, 'conpty.dll', `${architecture} conpty`)
+  await writeFixtureFile(sourceDirectory, 'OpenConsole.exe', `${architecture} console`)
+
+  return {
+    appOutDir,
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+    projectDirectory
+  }
+}
+
+async function writeFixtureFile(
+  directory: string,
+  fileName: string,
+  contents: string
+): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, fileName), contents, 'utf8')
+}


### PR DESCRIPTION
## Summary

- Copy conpty.dll and OpenConsole.exe beside the Windows conpty.node selected after Electron rebuilds native dependencies.
- Fail packaging when no loadable Windows ConPTY module is present.
- Run a packaged Windows terminal smoke test during PR CI and upload diagnostics from packaged-smoke failures.

## Root cause

The regular Electron E2E suite loaded node-pty from the workspace prebuild, where the bundled ConPTY runtime was already present. Electron Builder rebuilt node-pty into build/Release, which has higher load priority, but did not rerun node-pty's postinstall copy step. Packaged Windows terminals therefore started without the adjacent ConPTY runtime.

## Verification

- pnpm vitest run tests/unit/support/windows-node-pty-packaging.spec.ts
- pnpm package
- pnpm pre-commit
- git diff --check

The PR workflow now performs the remaining real Windows packaged-runtime verification.