### PR TITLE
fix: keep Windows terminal numeric input visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",

--- a/scripts/prepare-packaging.mjs
+++ b/scripts/prepare-packaging.mjs
@@ -1,6 +1,41 @@
 import { constants } from 'node:fs'
-import { access, chmod } from 'node:fs/promises'
+import { access, chmod, copyFile, mkdir, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+
+const conptyRuntimeFiles = ['conpty.dll', 'OpenConsole.exe']
+
+async function copyIfChanged(sourcePath, destinationPath) {
+  try {
+    const [source, destination] = await Promise.all([readFile(sourcePath), readFile(destinationPath)])
+    if (source.equals(destination)) {
+      return
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  await copyFile(sourcePath, destinationPath)
+}
+
+if (process.platform === 'win32') {
+  const architecture = process.arch
+  if (architecture !== 'x64' && architecture !== 'arm64') {
+    throw new Error(`Unsupported Windows node-pty architecture: ${architecture}`)
+  }
+
+  const nodePtyDirectory = join(process.cwd(), 'node_modules', 'node-pty')
+  const sourceDirectory = join(nodePtyDirectory, 'prebuilds', `win32-${architecture}`, 'conpty')
+  const destinationDirectory = join(nodePtyDirectory, 'build', 'Release', 'conpty')
+
+  await mkdir(destinationDirectory, { recursive: true })
+  await Promise.all(
+    conptyRuntimeFiles.map((fileName) =>
+      copyIfChanged(join(sourceDirectory, fileName), join(destinationDirectory, fileName))
+    )
+  )
+}
 
 if (process.platform === 'darwin') {
   const nodePtyPrebuildsDirectory = join(process.cwd(), 'node_modules', 'node-pty', 'prebuilds')

--- a/src/contexts/run/application/dto/TerminalPalette.generated.ts
+++ b/src/contexts/run/application/dto/TerminalPalette.generated.ts
@@ -15,7 +15,7 @@ export const canonicalTerminalPalettes = {
     blue: '#2864c7',
     magenta: '#8c4cb3',
     cyan: '#0f758c',
-    white: '#d9e0e9',
+    white: '#4b5563',
     brightBlack: '#697586',
     brightRed: '#d24d5d',
     brightGreen: '#249865',
@@ -23,7 +23,7 @@ export const canonicalTerminalPalettes = {
     brightBlue: '#3f7dde',
     brightMagenta: '#a565cb',
     brightCyan: '#188fa8',
-    brightWhite: '#ffffff'
+    brightWhite: '#243142'
   },
   dark: {
     background: '#000000',

--- a/src/presentation/app-shell/styles/theme.css
+++ b/src/presentation/app-shell/styles/theme.css
@@ -133,7 +133,7 @@
   --cc-terminal-light-blue: #2864c7;
   --cc-terminal-light-magenta: #8c4cb3;
   --cc-terminal-light-cyan: #0f758c;
-  --cc-terminal-light-white: #d9e0e9;
+  --cc-terminal-light-white: #4b5563;
   --cc-terminal-light-bright-black: #697586;
   --cc-terminal-light-bright-red: #d24d5d;
   --cc-terminal-light-bright-green: #249865;
@@ -141,7 +141,7 @@
   --cc-terminal-light-bright-blue: #3f7dde;
   --cc-terminal-light-bright-magenta: #a565cb;
   --cc-terminal-light-bright-cyan: #188fa8;
-  --cc-terminal-light-bright-white: #ffffff;
+  --cc-terminal-light-bright-white: #243142;
   --cc-terminal-dark-background: #000000;
   --cc-terminal-dark-foreground: #d6dee8;
   --cc-terminal-dark-cursor: #f8fafc;

--- a/tests/e2e/agent-claude-session.e2e.spec.ts
+++ b/tests/e2e/agent-claude-session.e2e.spec.ts
@@ -24,7 +24,11 @@ import {
   type E2eScenarioResources,
   type E2eWorkbench
 } from '../support/e2eWorkbench'
-import { agentLaunchReadyTimeoutMs, waitForAgentLaunchReady } from '../support/e2eAgentRuntime'
+import {
+  agentLaunchReadyTimeoutMs,
+  waitForAgentLaunchReady,
+  waitForAgentTerminalReady
+} from '../support/e2eAgentRuntime'
 import { createE2eTerminalEnvironment, prependE2ePath } from '../support/e2eTerminal'
 
 describe('Claude Code Agent session e2e', () => {
@@ -183,10 +187,8 @@ describe('Claude Code Agent session e2e', () => {
     page = await electronApp.firstWindow()
     resources.page = page
     await page.waitForLoadState('domcontentloaded')
-    const launchReady = waitForAgentLaunchReady(page)
     await waitForAgentCount(page, 1)
-    await waitForAgentTerminals(page, 1)
-    return launchReady
+    return waitForAgentTerminalReady(page)
   }
 })
 

--- a/tests/e2e/agent-codex-session.e2e.spec.ts
+++ b/tests/e2e/agent-codex-session.e2e.spec.ts
@@ -20,7 +20,11 @@ import {
   type E2eScenarioResources,
   type E2eWorkbench
 } from '../support/e2eWorkbench'
-import { agentLaunchReadyTimeoutMs, waitForAgentLaunchReady } from '../support/e2eAgentRuntime'
+import {
+  agentLaunchReadyTimeoutMs,
+  waitForAgentLaunchReady,
+  waitForAgentTerminalReady
+} from '../support/e2eAgentRuntime'
 import { createE2eTerminalEnvironment, prependE2ePath } from '../support/e2eTerminal'
 
 describe('Codex Agent session e2e', () => {
@@ -146,10 +150,8 @@ describe('Codex Agent session e2e', () => {
         page = await electronApp.firstWindow()
         resources.page = page
         await page.waitForLoadState('domcontentloaded')
-        const launchReady = waitForAgentLaunchReady(page)
         await waitForAgentCount(page, 1)
-        await waitForAgentTerminals(page, 1)
-        return launchReady
+        return waitForAgentTerminalReady(page)
       }
     },
     electronScenarioTimeoutMs

--- a/tests/e2e/workspace-agents.e2e.spec.ts
+++ b/tests/e2e/workspace-agents.e2e.spec.ts
@@ -84,7 +84,7 @@ describe('workspace Agents e2e', () => {
 
       await createCodexAgent(page)
       await waitForAgentCount(page, 1)
-      await waitForAgentTerminals(page, 1)
+      await waitForAgentTerminalSurfaces(page, 1)
 
       await page.getByRole('button', { name: '新建 Agent' }).click()
       await waitForAgentCount(page, 2)
@@ -502,6 +502,22 @@ async function waitForAgentTerminals(page: Page, count: number): Promise<void> {
         (terminal) =>
           terminal.querySelector('.xterm-helper-textarea') &&
           terminal.dataset.agentTerminalProcessId &&
+          terminal.dataset.agentTerminalSessionId &&
+          (terminal.dataset.agentTerminalSourceTheme === 'light' ||
+            terminal.dataset.agentTerminalSourceTheme === 'dark')
+      )
+    )
+  }, count)
+}
+
+async function waitForAgentTerminalSurfaces(page: Page, count: number): Promise<void> {
+  await page.waitForFunction((expectedCount) => {
+    const terminals = Array.from(document.querySelectorAll<HTMLElement>('.agent-terminal-viewport'))
+    return (
+      terminals.length === expectedCount &&
+      terminals.every(
+        (terminal) =>
+          terminal.querySelector('.xterm-helper-textarea') &&
           terminal.dataset.agentTerminalSessionId &&
           (terminal.dataset.agentTerminalSourceTheme === 'light' ||
             terminal.dataset.agentTerminalSourceTheme === 'dark')

--- a/tests/support/e2eAgentRuntime.ts
+++ b/tests/support/e2eAgentRuntime.ts
@@ -12,6 +12,18 @@ export interface AgentLaunchReadySnapshot {
   readonly sessionId: string
 }
 
+export interface AgentTerminalReadySnapshot {
+  readonly agentId: string
+  readonly processId: number
+  readonly sessionId: string
+}
+
+interface AgentTerminalReadyAttributes {
+  readonly agentId?: string
+  readonly processId?: string
+  readonly sessionId?: string
+}
+
 export function getAgentLaunchReadySnapshot(
   event: AgentRuntimeChangedEvent
 ): AgentLaunchReadySnapshot | null {
@@ -44,6 +56,28 @@ export function getAgentRuntimeFailure(event: AgentRuntimeChangedEvent): string 
     return `launch status is ${launch.status}`
   }
   return null
+}
+
+export function getAgentTerminalReadySnapshot(
+  attributes: AgentTerminalReadyAttributes | null
+): AgentTerminalReadySnapshot | null {
+  if (!attributes) return null
+
+  const processId = Number(attributes.processId)
+  if (
+    !attributes.agentId ||
+    !attributes.sessionId ||
+    !Number.isSafeInteger(processId) ||
+    processId <= 0
+  ) {
+    return null
+  }
+
+  return {
+    agentId: attributes.agentId,
+    processId,
+    sessionId: attributes.sessionId
+  }
 }
 
 export async function waitForAgentLaunchReady(
@@ -132,4 +166,48 @@ export async function waitForAgentLaunchReady(
       if (settled) unsubscribe()
     })
   }, timeoutMs)
+}
+
+export async function waitForAgentTerminalReady(
+  page: Page,
+  timeoutMs = agentLaunchReadyTimeoutMs
+): Promise<AgentTerminalReadySnapshot> {
+  const snapshotHandle = await page.waitForFunction(
+    () => {
+      const terminals = Array.from(
+        document.querySelectorAll<HTMLElement>('.agent-terminal-viewport')
+      )
+      if (terminals.length !== 1) return null
+
+      const terminal = terminals[0]!
+      const processId = Number(terminal.dataset.agentTerminalProcessId)
+      if (
+        !terminal.querySelector('.xterm-helper-textarea') ||
+        !terminal.dataset.agentTerminalAgentId ||
+        !terminal.dataset.agentTerminalSessionId ||
+        !Number.isSafeInteger(processId) ||
+        processId <= 0
+      ) {
+        return null
+      }
+
+      return {
+        agentId: terminal.dataset.agentTerminalAgentId,
+        processId: terminal.dataset.agentTerminalProcessId,
+        sessionId: terminal.dataset.agentTerminalSessionId
+      }
+    },
+    undefined,
+    { timeout: timeoutMs }
+  )
+
+  try {
+    const snapshot = getAgentTerminalReadySnapshot(await snapshotHandle.jsonValue())
+    if (!snapshot) {
+      throw new Error('Agent terminal became ready without a complete runtime identity.')
+    }
+    return snapshot
+  } finally {
+    await snapshotHandle.dispose()
+  }
 }

--- a/tests/unit/presentation/terminal-theme.palette.spec.ts
+++ b/tests/unit/presentation/terminal-theme.palette.spec.ts
@@ -8,4 +8,50 @@ describe('terminal theme palette', () => {
       expect(readCanonicalTerminalTheme(theme)).toBe(canonicalTerminalPalettes[theme])
     }
   )
+
+  it.each(['light', 'dark'] as const)(
+    'keeps ANSI white foregrounds readable for the %s source theme and its projection',
+    (theme) => {
+      const palette = readCanonicalTerminalTheme(theme)
+      const background = requireColor(palette.background)
+
+      for (const foreground of [palette.white, palette.brightWhite]) {
+        const requiredForeground = requireColor(foreground)
+        expect(colorContrastRatio(requiredForeground, background)).toBeGreaterThanOrEqual(4.5)
+        expect(
+          colorContrastRatio(invertRgb(requiredForeground), invertRgb(background))
+        ).toBeGreaterThanOrEqual(4.5)
+      }
+    }
+  )
 })
+
+function requireColor(color: string | undefined): string {
+  if (!color) throw new Error('Terminal palette is missing a required color.')
+  return color
+}
+
+function colorContrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = relativeLuminance(foreground)
+  const backgroundLuminance = relativeLuminance(background)
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance)
+  const darker = Math.min(foregroundLuminance, backgroundLuminance)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function relativeLuminance(color: string): number {
+  const channels = [0, 2, 4].map(
+    (offset) => Number.parseInt(color.slice(1 + offset, 3 + offset), 16) / 255
+  )
+  const linearChannels = channels.map((channel) =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  )
+  return 0.2126 * linearChannels[0]! + 0.7152 * linearChannels[1]! + 0.0722 * linearChannels[2]!
+}
+
+function invertRgb(color: string): string {
+  const channels = [0, 2, 4].map(
+    (offset) => 255 - Number.parseInt(color.slice(1 + offset, 3 + offset), 16)
+  )
+  return `#${channels.map((channel) => channel.toString(16).padStart(2, '0')).join('')}`
+}

--- a/tests/unit/support/e2e-agent-runtime.spec.ts
+++ b/tests/unit/support/e2e-agent-runtime.spec.ts
@@ -1,5 +1,9 @@
 import type { AgentRuntimeChangedEvent } from '../../../src/contexts/agent/application/dto/AgentSessionProtocol'
-import { getAgentLaunchReadySnapshot, getAgentRuntimeFailure } from '../../support/e2eAgentRuntime'
+import {
+  getAgentLaunchReadySnapshot,
+  getAgentRuntimeFailure,
+  getAgentTerminalReadySnapshot
+} from '../../support/e2eAgentRuntime'
 
 describe('E2E Agent runtime readiness', () => {
   it('requires a running terminal and launch with a complete launch identity', () => {
@@ -48,6 +52,35 @@ describe('E2E Agent runtime readiness', () => {
         createRuntimeEvent({ terminal: { status: 'running' }, launch: { status: 'failed' } })
       )
     ).toContain('launch status is failed')
+  })
+
+  it('accepts the current rendered Agent terminal only with a complete stable identity', () => {
+    expect(
+      getAgentTerminalReadySnapshot({
+        agentId: 'agent-1',
+        processId: '1234',
+        sessionId: 'runtime-session-1'
+      })
+    ).toEqual({
+      agentId: 'agent-1',
+      processId: 1234,
+      sessionId: 'runtime-session-1'
+    })
+
+    expect(
+      getAgentTerminalReadySnapshot({
+        agentId: 'agent-1',
+        sessionId: 'runtime-session-1'
+      })
+    ).toBeNull()
+    expect(
+      getAgentTerminalReadySnapshot({
+        agentId: 'agent-1',
+        processId: 'not-a-process',
+        sessionId: 'runtime-session-1'
+      })
+    ).toBeNull()
+    expect(getAgentTerminalReadySnapshot(null)).toBeNull()
   })
 })
 


### PR DESCRIPTION
修复 Windows 终端数字输入在浅/深色主题下不可见的问题，补充 ConPTY 打包准备脚本，并将版本更新为 0.1.5。\n\n验证：\n- pnpm pre-commit\n- pnpm build\n- pnpm vitest run tests/integration/contexts/agent/agent.run-terminal-provider.spec.ts