### PR TITLE
chore(release): prepare v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",


### PR DESCRIPTION
## Summary

- bump the CleanCode package version from 0.1.5 to 0.1.6
- prepare the matching v0.1.6 Preview release tag

## Validation

- `pnpm pre-commit`
- `pnpm build`

## Release

After this PR is merged, tag the merged `main` commit as `v0.1.6`. The existing release workflow will build and smoke-test macOS, Windows, and Linux artifacts before publishing the GitHub Pre-release.