### PR TITLE
fix(sidebar): restore scrolling and stabilize width

### DIFF
--- a/src/presentation/app-shell/ProjectSidebar.tsx
+++ b/src/presentation/app-shell/ProjectSidebar.tsx
@@ -204,6 +204,7 @@ function ProjectCard({
   const [archiveWorkspaceId, setArchiveWorkspaceId] = useState<string | null>(null)
   const [isRemoveProjectDialogOpen, setIsRemoveProjectDialogOpen] = useState(false)
   const [handledIntentId, setHandledIntentId] = useState<number | null>(null)
+  const branchSelectorPopoverRef = useRef<HTMLDivElement>(null)
   const branchSelectorRootRef = useRef<HTMLDivElement>(null)
   const removeProjectButtonRef = useRef<HTMLButtonElement>(null)
   const {
@@ -277,8 +278,13 @@ function ProjectCard({
     const closeBranchSelectorWhenClickingOutside = (event: PointerEvent): void => {
       const target = event.target
 
-      if (target instanceof Node && branchSelectorRootRef.current?.contains(target)) {
-        return
+      if (target instanceof Node) {
+        if (
+          branchSelectorRootRef.current?.contains(target) ||
+          branchSelectorPopoverRef.current?.contains(target)
+        ) {
+          return
+        }
       }
 
       closeBranchSelector()
@@ -437,7 +443,9 @@ function ProjectCard({
                       </div>
                       {isBranchSelectorOpen ? (
                         <BranchSelectorPopover
+                          anchorRef={branchSelectorRootRef}
                           branches={workbench.gitBranches}
+                          popoverRef={branchSelectorPopoverRef}
                           searchQuery={branchSearchQuery}
                           onSearchQueryChange={setBranchSearchQuery}
                           onChooseBranch={(branch) => {

--- a/src/presentation/app-shell/ProjectSidebarBranchSelector.tsx
+++ b/src/presentation/app-shell/ProjectSidebarBranchSelector.tsx
@@ -1,4 +1,6 @@
 import { Check, GitBranch, Plus, Search } from 'lucide-react'
+import { useLayoutEffect, useState, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 
 import type { WorkbenchSnapshot } from './types'
 import { useI18n } from './i18n/useI18n'
@@ -6,27 +8,73 @@ import { useI18n } from './i18n/useI18n'
 type GitBranchNavigationItem = WorkbenchSnapshot['gitBranches'][number]
 
 interface BranchSelectorPopoverProps {
+  readonly anchorRef: RefObject<HTMLElement | null>
   readonly branches: readonly GitBranchNavigationItem[]
+  readonly popoverRef: RefObject<HTMLDivElement | null>
   readonly searchQuery: string
   readonly onSearchQueryChange: (query: string) => void
   readonly onChooseBranch: (branch: GitBranchNavigationItem) => void
 }
 
+interface BranchSelectorPopoverPosition {
+  readonly left: number
+  readonly top: number
+}
+
 export function BranchSelectorPopover({
+  anchorRef,
   branches,
+  popoverRef,
   searchQuery,
   onSearchQueryChange,
   onChooseBranch
 }: BranchSelectorPopoverProps) {
   const { t } = useI18n()
+  const [position, setPosition] = useState<BranchSelectorPopoverPosition | null>(null)
   const normalizedQuery = searchQuery.trim().toLocaleLowerCase()
   const visibleBranches = normalizedQuery
     ? branches.filter((branch) => branch.name.toLocaleLowerCase().includes(normalizedQuery))
     : branches
   const orderedVisibleBranches = orderBranchSelectorItems(visibleBranches)
 
-  return (
-    <div className="branch-selector-popover" role="dialog" aria-label={t('branchSelector.dialog')}>
+  useLayoutEffect(() => {
+    const positionPopover = (): void => {
+      const anchor = anchorRef.current
+      const popover = popoverRef.current
+      if (!anchor || !popover) return
+
+      setPosition(
+        resolveBranchSelectorPopoverPosition({
+          anchorRect: anchor.getBoundingClientRect(),
+          popoverHeight: popover.offsetHeight,
+          popoverWidth: popover.offsetWidth,
+          viewportHeight: window.innerHeight,
+          viewportWidth: window.innerWidth
+        })
+      )
+    }
+
+    positionPopover()
+    window.addEventListener('resize', positionPopover)
+    window.addEventListener('scroll', positionPopover, true)
+    return () => {
+      window.removeEventListener('resize', positionPopover)
+      window.removeEventListener('scroll', positionPopover, true)
+    }
+  }, [anchorRef, popoverRef])
+
+  return createPortal(
+    <div
+      className="branch-selector-popover"
+      ref={popoverRef}
+      role="dialog"
+      aria-label={t('branchSelector.dialog')}
+      style={{
+        left: position?.left ?? 0,
+        top: position?.top ?? 0,
+        visibility: position ? 'visible' : 'hidden'
+      }}
+    >
       <label className="sr-only" htmlFor="branch-selector-search">
         {t('branchSelector.search')}
       </label>
@@ -82,8 +130,34 @@ export function BranchSelectorPopover({
         <Plus size={16} aria-hidden="true" />
         {t('branchSelector.create')}
       </button>
-    </div>
+    </div>,
+    document.body
   )
+}
+
+function resolveBranchSelectorPopoverPosition(input: {
+  readonly anchorRect: DOMRect
+  readonly popoverHeight: number
+  readonly popoverWidth: number
+  readonly viewportHeight: number
+  readonly viewportWidth: number
+}): BranchSelectorPopoverPosition {
+  const viewportPadding = 8
+  const horizontalGap = 10
+  const preferredTopOffset = 64
+  const maxLeft = Math.max(
+    viewportPadding,
+    input.viewportWidth - input.popoverWidth - viewportPadding
+  )
+  const maxTop = Math.max(
+    viewportPadding,
+    input.viewportHeight - input.popoverHeight - viewportPadding
+  )
+
+  return {
+    left: Math.min(Math.max(input.anchorRect.right + horizontalGap, viewportPadding), maxLeft),
+    top: Math.min(Math.max(input.anchorRect.top - preferredTopOffset, viewportPadding), maxTop)
+  }
 }
 
 function orderBranchSelectorItems(

--- a/src/presentation/app-shell/styles/base.css
+++ b/src/presentation/app-shell/styles/base.css
@@ -8,7 +8,7 @@
 }
 
 .app-shell {
-  --cc-sidebar-width: clamp(220px, 17vw, 252px);
+  --cc-sidebar-width: 280px;
   position: relative;
   display: grid;
   width: 100%;
@@ -120,7 +120,6 @@ textarea:focus-visible {
 
 @media (max-width: 1120px) {
   .app-shell {
-    --cc-sidebar-width: 220px;
     grid-template-columns: var(--cc-sidebar-width) minmax(400px, 1fr);
   }
 

--- a/src/presentation/app-shell/styles/project-sidebar.css
+++ b/src/presentation/app-shell/styles/project-sidebar.css
@@ -143,7 +143,23 @@
   flex: 1 1 auto;
   margin-top: 6px;
   padding: 0 4px 44px;
-  overflow: visible;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--cc-scrollbar) transparent;
+  scrollbar-width: thin;
+}
+
+.project-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.project-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.project-list::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: var(--cc-scrollbar);
 }
 
 .project-list--dragging {
@@ -485,10 +501,8 @@
 }
 
 .branch-selector-popover {
-  position: absolute;
-  top: -64px;
-  left: calc(100% + 10px);
-  z-index: 40;
+  position: fixed;
+  z-index: 200;
   width: min(300px, calc(100vw - 32px));
   border: 1px solid var(--cc-border);
   border-radius: 11px;

--- a/tests/e2e/agent-terminal-theme-workspaces.e2e.spec.ts
+++ b/tests/e2e/agent-terminal-theme-workspaces.e2e.spec.ts
@@ -236,7 +236,7 @@ describe('Agent terminal theme across workspaces e2e', () => {
         name: `项目 ${basename(workbench.projectDirectory)}`
       })
       await projectCard.getByRole('button', { name: /选择默认工作区分支/ }).click()
-      await projectCard
+      await page
         .getByRole('dialog', { name: '选择默认工作区分支' })
         .getByRole('button', {
           name: branchName,

--- a/tests/e2e/project-workspaces.e2e.spec.ts
+++ b/tests/e2e/project-workspaces.e2e.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { mkdir } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import type { ElectronApplication, Locator, Page } from 'playwright'
@@ -73,6 +74,7 @@ describe('project workspaces e2e', () => {
         sidebar: {
           backgroundColor: 'rgba(0, 0, 0, 0)',
           borderRightWidth: '0px',
+          width: 280,
           y: 36
         }
       })
@@ -93,7 +95,8 @@ describe('project workspaces e2e', () => {
         navigation: { height: 36, width: windowedTitlebarInset + 32, x: 0, y: 0 },
         sidebar: {
           backgroundColor: 'rgba(0, 0, 0, 0)',
-          borderRightWidth: '0px'
+          borderRightWidth: '0px',
+          width: 0
         }
       })
       await expandSidebar.click()
@@ -107,7 +110,8 @@ describe('project workspaces e2e', () => {
       await waitForSidebarTitlebarGeometry(page, 'fullscreen sidebar titlebar geometry', {
         button: { height: 24, width: 32, x: 0, y: 6 },
         buttonOwnsHitTarget: true,
-        navigation: { height: 36, x: 0, y: 0 }
+        navigation: { height: 36, x: 0, y: 0 },
+        sidebar: { width: 280 }
       })
 
       await titlebarNavigation.getByRole('button', { name: '收起侧边栏' }).click()
@@ -126,8 +130,49 @@ describe('project workspaces e2e', () => {
       await waitForSidebarTitlebarGeometry(page, 'restored windowed titlebar geometry', {
         button: { height: 24, width: 32, x: windowedTitlebarInset, y: 6 },
         buttonOwnsHitTarget: true,
-        navigation: { height: 36, x: 0, y: 0 }
+        navigation: { height: 36, x: 0, y: 0 },
+        sidebar: { width: 280 }
       })
+    },
+    electronScenarioTimeoutMs
+  )
+
+  it(
+    'scrolls overflowing projects inside the sidebar',
+    async () => {
+      await expectDesktopRuntime(page)
+
+      for (let index = 1; index <= 8; index += 1) {
+        const projectName = `sidebar-project-${index}`
+        const projectDirectory = join(workbench.projectDirectory, projectName)
+        await mkdir(projectDirectory)
+        await electronApp.evaluate((_electron, directory) => {
+          process.env.CLEANCODE_TEST_PROJECT_DIRECTORY = directory
+        }, projectDirectory)
+        await page.getByRole('button', { name: '添加项目' }).click()
+        await page.getByRole('button', { name: projectName, exact: true }).waitFor()
+      }
+
+      const projectList = page.locator('.project-list')
+      const initialGeometry = await projectList.evaluate((element) => ({
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+        scrollTop: element.scrollTop
+      }))
+      expect(initialGeometry.scrollHeight).toBeGreaterThan(initialGeometry.clientHeight)
+      expect(initialGeometry.scrollTop).toBe(0)
+
+      await projectList.hover()
+      await page.mouse.wheel(0, 360)
+
+      const scrollTop = await pollUntilState({
+        description: 'project list to scroll after a wheel gesture',
+        observe: () => projectList.evaluate((element) => element.scrollTop),
+        accept: (value) => value > 0,
+        timeoutMs: 5_000
+      })
+      expect(scrollTop).toBeGreaterThan(0)
+      await page.getByRole('button', { name: '添加项目' }).waitFor()
     },
     electronScenarioTimeoutMs
   )
@@ -193,6 +238,7 @@ async function readSidebarTitlebarGeometry(page: Page): Promise<{
   readonly sidebar: {
     readonly backgroundColor: string
     readonly borderRightWidth: string
+    readonly width: number
     readonly y: number
   }
 }> {
@@ -238,6 +284,7 @@ async function readSidebarTitlebarGeometry(page: Page): Promise<{
       sidebar: {
         backgroundColor: sidebarStyle.backgroundColor,
         borderRightWidth: sidebarStyle.borderRightWidth,
+        width: round(sidebarRect.width),
         y: round(sidebarRect.y)
       }
     }

--- a/tests/unit/presentation/app-shell.render.spec.tsx
+++ b/tests/unit/presentation/app-shell.render.spec.tsx
@@ -446,14 +446,18 @@ describe('app shell', () => {
 
     const branchDialog = await screen.findByRole('dialog', { name: '选择默认工作区分支' })
     const branchOptionButtons = within(branchDialog).getAllByRole('button')
+    const branchSearch = within(branchDialog).getByPlaceholderText('搜索分支')
 
-    expect(within(branchDialog).getByPlaceholderText('搜索分支')).toBeInTheDocument()
+    expect(branchDialog.parentElement).toBe(document.body)
+    expect(branchSearch).toBeInTheDocument()
     expect(branchOptionButtons[0]).toHaveAccessibleName('main')
     expect(within(branchDialog).getByRole('button', { name: /feature\/free/ })).toBeEnabled()
     expect(
       within(branchDialog).getByRole('button', { name: /feature\/worktree.*独立工作区/ })
     ).toBeDisabled()
 
+    fireEvent.pointerDown(branchSearch)
+    expect(branchDialog).toBeInTheDocument()
     fireEvent.pointerDown(document.body)
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary

- make overflowing projects scroll inside the sidebar while keeping the primary action fixed
- render and reposition the branch selector outside the scroll container so it is not clipped
- use a consistent 280px expanded sidebar width across window sizes
- add Electron geometry and wheel-scroll regression coverage

## Testing

- `pnpm pre-commit`
  - 1,372 unit tests
  - 172 integration tests (6 platform-dependent skips)
  - 92 contract tests
  - 38 Electron E2E tests