### PR TITLE
feat: refine canvas theme and pointer

### DIFF
--- a/src/presentation/app-shell/assets/canvas-pointer.svg
+++ b/src/presentation/app-shell/assets/canvas-pointer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" style="color-scheme: light">
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" style="color-scheme: light">
   <path
     d="M3.25 2.9 20.8 9.15c1.05.37 1.08 1.82.05 2.24l-6.48 2.62-2.3 6.55c-.36 1.04-1.8 1.09-2.23.08L2.92 4.91C2.47 3.87 2.2 2.53 3.25 2.9Z"
     fill="CanvasText"

--- a/src/presentation/app-shell/styles/theme.css
+++ b/src/presentation/app-shell/styles/theme.css
@@ -1,8 +1,8 @@
 :root,
 :root[data-theme='light'] {
   color-scheme: light;
-  --cc-background: #eef1f5;
-  --cc-canvas: #eceff4;
+  --cc-background: #f2f4f5;
+  --cc-canvas: #e8eaeb;
   --cc-chrome: #f3f5f8;
   --cc-chrome-raised: #f8f9fb;
   --cc-chrome-translucent: rgb(243 245 248 / 78%);
@@ -54,10 +54,10 @@
   --cc-shadow: 0 10px 30px rgb(20 27 45 / 9%);
   --cc-shadow-floating: 0 16px 38px rgb(20 27 45 / 13%);
   --cc-shadow-node: 0 10px 28px rgb(20 27 45 / 13%);
-  --cc-preview-light-background: #f7f9fc;
+  --cc-preview-light-background: #e8eaeb;
   --cc-preview-light-surface: #ffffff;
   --cc-preview-light-muted: #c8d0dc;
-  --cc-preview-dark-background: #141920;
+  --cc-preview-dark-background: #17191b;
   --cc-preview-dark-surface: #222a35;
   --cc-preview-dark-muted: #5e6a79;
 }
@@ -65,7 +65,7 @@
 :root[data-theme='dark'] {
   color-scheme: dark;
   --cc-background: #101318;
-  --cc-canvas: #0d1015;
+  --cc-canvas: #17191b;
   --cc-chrome: #171b22;
   --cc-chrome-raised: #1b2028;
   --cc-chrome-translucent: rgb(23 27 34 / 82%);

--- a/tests/unit/presentation/workbench-canvas-cursor-styles.spec.ts
+++ b/tests/unit/presentation/workbench-canvas-cursor-styles.spec.ts
@@ -48,12 +48,12 @@ describe('workbench canvas cursor styles', () => {
     expect(placementRule).not.toContain('crosshair')
   })
 
-  it('ships a compact static vector cursor without a DOM-following animation', () => {
+  it('ships a compact 20px static vector cursor without a DOM-following animation', () => {
     expect(existsSync(cursorAssetPath)).toBe(true)
     const cursorAsset = existsSync(cursorAssetPath) ? readFileSync(cursorAssetPath, 'utf8') : ''
 
     expect(cursorAsset).toContain('<svg')
-    expect(cursorAsset).toMatch(/viewBox="0 0 (24|32) (24|32)"/)
+    expect(cursorAsset).toContain('width="20" height="20" viewBox="0 0 24 24"')
     expect(cursorAsset).not.toContain('<animate')
   })
 


### PR DESCRIPTION
## Summary

- refine the light canvas and sidebar neutrals with Spatial-inspired surface colors
- align dark canvas and preview backgrounds with the updated theme
- reduce the custom paper-plane canvas pointer from 24px to 20px while preserving its hotspot and shared cursor states

## Testing

- pnpm pre-commit
- 281 unit test files / 1458 tests passed
- 34 integration test files passed, 2 skipped / 172 tests passed, 6 skipped
- 14 contract test files / 92 tests passed
- 14 Electron E2E files / 40 tests passed