### PR TITLE
fix(canvas): smooth wheel zoom interactions

### DIFF
--- a/docs/product/ui-style-guide.md
+++ b/docs/product/ui-style-guide.md
@@ -155,11 +155,13 @@ Agent terminal 首次测量和 attach 进行中使用中性、尺寸稳定的反
 
 程序化画布相机运动由 `src/presentation/app-shell/workbenchViewportMotion.ts` 统一拥有。调用方必须通过 `instant`、`quick`、`spatial` 或 `adaptive-focus` intent 表达运动原因，不得直接调用 React Flow 的 viewport helper，也不得在消费者中维护裸时长、spring 参数或独立取消策略。`instant` 用于持久化 viewport 恢复和直接操控预览；`quick` 用于用户主动触发的 zoom 与适应画布；`spatial` 用于创建显露和对象集合定位；`adaptive-focus` 同时按当前 viewport、目标屏幕距离和 zoom 级差调整收敛速度。intent 的精确参数仍是实现细节，不构成产品契约。
 
+滚轮与触控板 wheel 缩放由 `src/presentation/app-shell/workbenchDirectZoom.ts` 统一拥有，输入接管位于 `src/presentation/app-shell/useWorkbenchDirectZoom.ts`。React Flow 的原生滚轮缩放保持关闭；输入按 wheel delta 模式规范化后在 `log2(zoom)` 上连续累积，同一显示帧内的事件只合并一次。一个 wheel burst 使用同一条快速、无回弹的临界阻尼曲线：新输入只从当前 presentation 重定向累计目标并继承当前 zoom 速度，不得为每个 wheel delta 分别排队播放动画，也不得通过首帧硬跳、距离截断或固定分段补间制造接缝。连续帧链已经排定时，后续 wheel 事件只能更新目标和 burst 结束时间，不得重置上一 presentation frame 的积分时钟；一帧前到达的高频事件必须作为同一批输入推进。不同刷新率在相同经过时间必须得到相同 presentation。每批输入必须从当前 presentation 计算指针下的世界坐标，并在各帧 viewport 中保持该锚点不漂移。一个 wheel burst 只在输入停止且曲线收敛后提交一次最终 viewport；程序化相机、画布平移或恢复输入会取消未完成的直接缩放，反向接管亦然。`nowheel` 内容继续优先接收自己的滚动，原生触摸 pinch 不受 wheel 接管影响；`prefers-reduced-motion` 下每次输入即时呈现，但仍等 burst 结束后统一提交。response 和收敛阈值是统一 owner 的实现细节，不构成产品契约。
+
 画布普通单选与空白返回的相机目标由 `src/presentation/app-shell/useCanvasSelectionViewport.ts` 统一协调，并继续交给上述相机 owner 执行。标题普通单选复用现有节点中心与可读缩放算法；空白返回捕获清除前的唯一整体选择，以同一节点中心为锚点精确回到 `35%`，不得重新计算全部内容的外接范围中心。没有唯一选择或锚点不可用时，以当前 viewport 中心缩放，不能从多选中任取节点。平移和缩放必须作为同一个 `adaptive-focus` 目标连续收敛，不能先缩放再平移或先停顿再启动第二段动画。新的选择、平移、缩放或其他定位输入必须从当前 presentation 重新定向；`prefers-reduced-motion` 下即时应用同一最终中心和缩放。终端多选、组合候选以及已经自行负责相机的快捷键和小地图入口不得叠加第二次选择聚焦。
 
 非即时程序化相机运动使用 `requestAnimationFrame` 驱动的临界阻尼 spring，阻尼比固定为 `1`，不产生装饰性回弹。当前 motion token 的 response 为：`quick` 约 `0.30s`、`spatial` 约 `0.34s`、`adaptive-focus` 约 `0.34–0.42s`；response 描述弹簧响应快慢，不是固定动画时长。统一 owner 必须在世界坐标相机中心与 `log2(zoom)` 上保存位置和速度，再逐帧投影为 React Flow viewport；不得以 viewport transform 的 X、Y 差值估算空间移动，否则锚定缩放会随节点绝对位置改变曲线。纯锚定缩放的空间移动距离为零，双向缩放在对数尺度保持同一节奏，只有相机中心真实跨越画布时才允许 flight。新目标必须从当前呈现值重新定向并继承速度。用户开始拖动、工作区恢复或更新的定位意图会立即取消旧运动，迟到完成不得重新激活旧目标。曲线、阈值和取消语义只能在统一 owner 中调整，并必须由距离、缩放、锚点漂移、缩放单调性、重新定向、异步完成和 reduced-motion 参数矩阵覆盖。
 
-依赖相机位置的同屏反馈必须与成功应用的 presentation frame 使用同一事实源。小地图 viewport 框通过相机 owner 的轻量实时信号逐帧跟随，订阅范围只覆盖框本身；不得为同步框而把程序化中间帧写回 `WorkbenchCanvas` React 状态、重渲染小地图节点或持久化 viewport。最终 viewport 仍只在有效运动完成时提交一次。
+依赖相机位置的同屏反馈必须与成功应用的 presentation frame 使用同一事实源。小地图 viewport 框与缩放百分比通过相机 owner 的轻量实时信号逐帧跟随，订阅和重渲染范围分别只覆盖框本身与百分比 `<output>`；不得为同步反馈而把程序化中间帧写回 `WorkbenchCanvas` React 状态、重渲染小地图节点或持久化 viewport。最终 viewport 仍只在有效运动完成时提交一次。
 
 画布空间对象的创建、组合展开收起和缩放细节层级由 `src/presentation/app-shell/workbenchObjectMotion.ts` 统一拥有。新对象必须先以最终节点几何进入画布，再通过外壳的裁剪、透明度和短暂边框强调从中心显露；不得缩放或逐帧改变 Terminal、Agent、xterm 网格和 resize 几何。创建后的程序化相机聚焦至少让对象先呈现一帧，并继续遵守统一相机 owner 的取消与最终焦点契约。
 

--- a/src/presentation/app-shell/CanvasMinimap.tsx
+++ b/src/presentation/app-shell/CanvasMinimap.tsx
@@ -22,6 +22,7 @@ import type { ApplicationShortcutTooltipLabels } from './applicationShortcutTool
 import { useI18n } from './i18n/useI18n'
 import { TooltipLabel } from './Tooltip'
 import { subscribeWorkbenchViewportMotionPresentation } from './workbenchViewportMotion'
+import { subscribeWorkbenchDirectZoomPresentation } from './workbenchDirectZoom'
 
 interface CanvasSize {
   readonly width: number
@@ -39,6 +40,7 @@ interface CanvasMinimapProps {
   readonly canvasViewport: CanvasViewportSnapshot
   readonly canvasSize: CanvasSize
   readonly viewportFrame?: ReactNode
+  readonly viewportMotionInstance?: ReactFlowInstance<WorkbenchFlowNode, Edge> | null
   readonly viewportZoom: number
   readonly shortcutTooltips: Pick<
     ApplicationShortcutTooltipLabels,
@@ -85,6 +87,7 @@ export function CanvasMinimap({
   canvasViewport,
   canvasSize,
   viewportFrame,
+  viewportMotionInstance,
   viewportZoom,
   shortcutTooltips,
   minimapNodeInteraction,
@@ -255,7 +258,11 @@ export function CanvasMinimap({
           >
             <Minus size={14} aria-hidden="true" />
           </MinimapControlButton>
-          <output aria-label={t('minimap.zoomLevel')}>{Math.round(viewportZoom * 100)}%</output>
+          <LiveCanvasMinimapZoomLevel
+            baseline={canvasViewport}
+            fallbackZoom={viewportZoom}
+            instance={viewportMotionInstance ?? null}
+          />
           <MinimapControlButton
             label={t('minimap.zoomInTitle')}
             tooltip={shortcutTooltips.zoomCanvasIn}
@@ -275,6 +282,51 @@ export function CanvasMinimap({
       </div>
     </div>
   )
+}
+
+function LiveCanvasMinimapZoomLevel({
+  baseline,
+  fallbackZoom,
+  instance
+}: {
+  readonly baseline: CanvasViewportSnapshot
+  readonly fallbackZoom: number
+  readonly instance: ReactFlowInstance<WorkbenchFlowNode, Edge> | null
+}) {
+  const { t } = useI18n()
+  const [presentation, setPresentation] = useState<{
+    readonly baseline: CanvasViewportSnapshot
+    readonly instance: ReactFlowInstance<WorkbenchFlowNode, Edge>
+    readonly zoom: number
+  } | null>(null)
+
+  useEffect(() => {
+    if (!instance) return undefined
+
+    const projectPresentation = (viewport: CanvasViewportSnapshot): void => {
+      setPresentation({ baseline, instance, zoom: viewport.zoom })
+    }
+    const unsubscribeProgrammatic = subscribeWorkbenchViewportMotionPresentation(
+      instance,
+      projectPresentation
+    )
+    const unsubscribeDirect = subscribeWorkbenchDirectZoomPresentation(
+      instance,
+      projectPresentation
+    )
+
+    return () => {
+      unsubscribeProgrammatic()
+      unsubscribeDirect()
+    }
+  }, [baseline, instance])
+
+  const zoom =
+    presentation?.baseline === baseline && presentation.instance === instance
+      ? presentation.zoom
+      : fallbackZoom
+
+  return <output aria-label={t('minimap.zoomLevel')}>{Math.round(zoom * 100)}%</output>
 }
 
 export function LiveCanvasMinimapViewportFrame({
@@ -297,13 +349,26 @@ export function LiveCanvasMinimapViewportFrame({
       return undefined
     }
 
-    return subscribeWorkbenchViewportMotionPresentation(instance, (viewport) => {
+    const projectPresentation = (viewport: CanvasViewportSnapshot): void => {
       setPresentation({
         baseline: fallbackViewport,
         instance,
         viewport
       })
-    })
+    }
+    const unsubscribeProgrammatic = subscribeWorkbenchViewportMotionPresentation(
+      instance,
+      projectPresentation
+    )
+    const unsubscribeDirect = subscribeWorkbenchDirectZoomPresentation(
+      instance,
+      projectPresentation
+    )
+
+    return () => {
+      unsubscribeProgrammatic()
+      unsubscribeDirect()
+    }
   }, [fallbackViewport, instance])
 
   const viewport =

--- a/src/presentation/app-shell/WorkbenchCanvas.tsx
+++ b/src/presentation/app-shell/WorkbenchCanvas.tsx
@@ -54,15 +54,14 @@ import { resolveCanvasObjectContextTarget } from './canvasObjectContextTarget'
 import { CanvasInitialWorkbenchState, CanvasStatusbar } from './WorkbenchCanvasStates'
 import { projectTerminalWorkflowBuildOntoEdges } from './terminalWorkflowBuildEdgePresentation'
 import type { TerminalWorkflowBuildPresentation } from './useTerminalWorkflowBuildChoreography'
-import {
-  cancelWorkbenchViewportMotion,
-  subscribeWorkbenchViewportMotionCompletion
-} from './workbenchViewportMotion'
+import { cancelWorkbenchViewportMotion } from './workbenchViewportMotion'
+import { cancelWorkbenchDirectZoom } from './workbenchDirectZoom'
+import { useWorkbenchDirectZoom } from './useWorkbenchDirectZoom'
 import {
   centerCanvasViewportOnMinimapPoint,
-  commitCompletedCanvasViewportMotion,
   persistCanvasViewportFromMoveEnd,
   restoreCanvasViewport,
+  subscribeCanvasViewportMotionCompletion,
   synchronizeCanvasViewportFromMove,
   toCanvasViewportSnapshot
 } from './workbenchCanvasViewport'
@@ -287,6 +286,12 @@ export function WorkbenchCanvas({
     reactFlowInstanceRef,
     shortcutPlatform
   })
+  useWorkbenchDirectZoom({
+    canvasSurfaceRef,
+    onViewportInteractionStart,
+    reactFlowInstanceRef,
+    viewportMotionInstance
+  })
   const moveCanvasViewportToMinimapCenter = (
     center: MinimapViewportCenter,
     persistViewport: boolean
@@ -420,16 +425,12 @@ export function WorkbenchCanvas({
             reactFlowInstanceRef.current = instance
             setViewportMotionInstance((currentInstance) => currentInstance ?? instance)
             unsubscribeViewportMotionRef.current?.()
-            unsubscribeViewportMotionRef.current = subscribeWorkbenchViewportMotionCompletion(
+            unsubscribeViewportMotionRef.current = subscribeCanvasViewportMotionCompletion({
               instance,
-              (completion) =>
-                commitCompletedCanvasViewportMotion({
-                  completion,
-                  onViewportChange: onViewportChangeRef.current,
-                  setCanvasViewport,
-                  setViewportZoom
-                })
-            )
+              onViewportChangeRef,
+              setCanvasViewport,
+              setViewportZoom
+            })
 
             if (currentWorkbench) {
               restoreCanvasViewport({
@@ -506,6 +507,7 @@ export function WorkbenchCanvas({
           onMoveStart={(event) => {
             if (event) {
               cancelWorkbenchViewportMotion(reactFlowInstanceRef.current ?? undefined)
+              cancelWorkbenchDirectZoom(reactFlowInstanceRef.current ?? undefined)
               onViewportInteractionStart?.()
             }
           }}
@@ -522,6 +524,7 @@ export function WorkbenchCanvas({
           selectionKeyCode={null}
           minZoom={minimumCanvasZoom}
           maxZoom={maximumCanvasZoom}
+          zoomOnScroll={false}
           proOptions={{ hideAttribution: true }}
         >
           <Background color="var(--cc-border-strong)" gap={24} size={1} />
@@ -538,6 +541,7 @@ export function WorkbenchCanvas({
                   instance={viewportMotionInstance}
                 />
               }
+              viewportMotionInstance={viewportMotionInstance}
               viewportZoom={viewportZoom}
               shortcutTooltips={shortcutTooltips}
               minimapNodeInteraction={minimapNodeInteraction}

--- a/src/presentation/app-shell/useWorkbenchDirectZoom.ts
+++ b/src/presentation/app-shell/useWorkbenchDirectZoom.ts
@@ -1,0 +1,83 @@
+import type { Edge, ReactFlowInstance } from '@xyflow/react'
+import { useEffect, type MutableRefObject, type RefObject } from 'react'
+
+import type { WorkbenchFlowNode } from './types'
+import { retargetWorkbenchDirectZoom, type WorkbenchDirectZoomInput } from './workbenchDirectZoom'
+import { cancelWorkbenchViewportMotion } from './workbenchViewportMotion'
+import { prefersReducedMotion } from './workbenchViewportMotionEnvironment'
+
+interface WorkbenchWheelZoomInput {
+  readonly ctrlKey: boolean
+  readonly deltaMode: number
+  readonly deltaY: number
+  readonly mac: boolean
+}
+
+export function resolveWorkbenchWheelZoomStops(input: WorkbenchWheelZoomInput): number {
+  const deltaScale =
+    input.deltaMode === WheelEvent.DOM_DELTA_LINE
+      ? 0.05
+      : input.deltaMode === WheelEvent.DOM_DELTA_PAGE
+        ? 1
+        : 0.002
+  const pinchScale = input.ctrlKey && input.mac ? 10 : 1
+  return -input.deltaY * deltaScale * pinchScale
+}
+
+export function useWorkbenchDirectZoom({
+  canvasSurfaceRef,
+  onViewportInteractionStart,
+  reactFlowInstanceRef,
+  viewportMotionInstance
+}: {
+  readonly canvasSurfaceRef: RefObject<HTMLDivElement | null>
+  readonly onViewportInteractionStart?: () => void
+  readonly reactFlowInstanceRef: MutableRefObject<ReactFlowInstance<WorkbenchFlowNode, Edge> | null>
+  readonly viewportMotionInstance: ReactFlowInstance<WorkbenchFlowNode, Edge> | null
+}): void {
+  useEffect(() => {
+    if (!viewportMotionInstance) return undefined
+
+    const renderer = canvasSurfaceRef.current?.querySelector<HTMLElement>('.react-flow__renderer')
+    if (!renderer) return undefined
+
+    const handleWheel = (event: WheelEvent): void => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+
+      if (target.closest('.nowheel')) {
+        if (event.ctrlKey) event.preventDefault()
+        return
+      }
+
+      const instance = reactFlowInstanceRef.current
+      if (!instance) return
+
+      const deltaZoomStops = resolveWorkbenchWheelZoomStops({
+        ctrlKey: event.ctrlKey,
+        deltaMode: event.deltaMode,
+        deltaY: event.deltaY,
+        mac: isMacPlatform()
+      })
+      if (!Number.isFinite(deltaZoomStops) || deltaZoomStops === 0) return
+
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      const bounds = renderer.getBoundingClientRect()
+      cancelWorkbenchViewportMotion(instance)
+      const input: WorkbenchDirectZoomInput = {
+        anchor: { x: event.clientX - bounds.left, y: event.clientY - bounds.top },
+        deltaZoomStops,
+        reducedMotion: prefersReducedMotion()
+      }
+      if (retargetWorkbenchDirectZoom(instance, input)) onViewportInteractionStart?.()
+    }
+
+    renderer.addEventListener('wheel', handleWheel, { capture: true, passive: false })
+    return () => renderer.removeEventListener('wheel', handleWheel, { capture: true })
+  }, [canvasSurfaceRef, onViewportInteractionStart, reactFlowInstanceRef, viewportMotionInstance])
+}
+
+function isMacPlatform(): boolean {
+  return typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent)
+}

--- a/src/presentation/app-shell/workbenchCanvasViewport.ts
+++ b/src/presentation/app-shell/workbenchCanvasViewport.ts
@@ -4,9 +4,11 @@ import type { MutableRefObject } from 'react'
 import type { MinimapViewportCenter } from './CanvasMinimap'
 import type { WorkbenchFlowNode, WorkbenchSnapshot } from './types'
 import {
+  subscribeWorkbenchViewportMotionCompletion,
   transitionWorkbenchViewport,
   type WorkbenchViewportMotionCompletion
 } from './workbenchViewportMotion'
+import { subscribeWorkbenchDirectZoomCompletion } from './workbenchDirectZoom'
 
 interface CanvasViewportProjection {
   readonly setViewportZoom: (zoom: number) => void
@@ -61,6 +63,22 @@ interface CommitCompletedCanvasViewportMotionInput
   readonly completion: WorkbenchViewportMotionCompletion
 }
 
+interface CommitCanvasViewportInput extends CanvasViewportProjection, CanvasViewportPersistence {
+  readonly viewport: Viewport
+}
+
+function commitCanvasViewport({
+  viewport,
+  onViewportChange,
+  setViewportZoom,
+  setCanvasViewport
+}: CommitCanvasViewportInput): void {
+  const canvasViewport = toCanvasViewportSnapshot(viewport)
+  setViewportZoom(canvasViewport.zoom)
+  setCanvasViewport(canvasViewport)
+  onViewportChange(canvasViewport)
+}
+
 export function commitCompletedCanvasViewportMotion({
   completion,
   onViewportChange,
@@ -71,10 +89,46 @@ export function commitCompletedCanvasViewportMotion({
     return
   }
 
-  const canvasViewport = toCanvasViewportSnapshot(completion.viewport)
-  setViewportZoom(canvasViewport.zoom)
-  setCanvasViewport(canvasViewport)
-  onViewportChange(canvasViewport)
+  commitCanvasViewport({
+    viewport: completion.viewport,
+    onViewportChange,
+    setViewportZoom,
+    setCanvasViewport
+  })
+}
+
+export function subscribeCanvasViewportMotionCompletion({
+  instance,
+  onViewportChangeRef,
+  setViewportZoom,
+  setCanvasViewport
+}: CanvasViewportProjection & {
+  readonly instance: ReactFlowInstance<WorkbenchFlowNode, Edge>
+  readonly onViewportChangeRef: MutableRefObject<CanvasViewportPersistence['onViewportChange']>
+}): () => void {
+  const unsubscribeProgrammatic = subscribeWorkbenchViewportMotionCompletion(
+    instance,
+    (completion) =>
+      commitCompletedCanvasViewportMotion({
+        completion,
+        onViewportChange: onViewportChangeRef.current,
+        setCanvasViewport,
+        setViewportZoom
+      })
+  )
+  const unsubscribeDirect = subscribeWorkbenchDirectZoomCompletion(instance, ({ viewport }) =>
+    commitCanvasViewport({
+      viewport,
+      onViewportChange: onViewportChangeRef.current,
+      setCanvasViewport,
+      setViewportZoom
+    })
+  )
+
+  return () => {
+    unsubscribeProgrammatic()
+    unsubscribeDirect()
+  }
 }
 
 interface RestoreCanvasViewportInput {

--- a/src/presentation/app-shell/workbenchDirectZoom.ts
+++ b/src/presentation/app-shell/workbenchDirectZoom.ts
@@ -1,0 +1,366 @@
+import type { Edge, ReactFlowInstance, Viewport } from '@xyflow/react'
+
+import {
+  maximumCanvasZoom,
+  minimumCanvasZoom
+} from '../../contexts/block-graph/application/dto/BlockGraphSnapshot'
+import type { WorkbenchFlowNode } from './types'
+import {
+  browserViewportMotionFrameScheduler,
+  type WorkbenchViewportMotionFrameScheduler
+} from './workbenchViewportMotionEnvironment'
+import {
+  advanceCriticalSpringAxis,
+  isCriticalSpringAxisSettled,
+  type CriticalSpringAxis
+} from './workbenchViewportSpring'
+
+export interface WorkbenchDirectZoomCompletion {
+  readonly viewport: Viewport
+}
+
+export type WorkbenchDirectZoomCompletionListener = (
+  completion: WorkbenchDirectZoomCompletion
+) => void
+
+export type WorkbenchDirectZoomPresentationListener = (viewport: Viewport) => void
+
+export interface WorkbenchDirectZoomInput {
+  readonly anchor: { readonly x: number; readonly y: number }
+  readonly deltaZoomStops: number
+  readonly reducedMotion: boolean
+}
+
+export interface WorkbenchDirectZoomController {
+  readonly cancel: (instance?: ReactFlowInstance<WorkbenchFlowNode, Edge>) => void
+  readonly retarget: (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    input: WorkbenchDirectZoomInput
+  ) => boolean
+  readonly subscribe: (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: WorkbenchDirectZoomCompletionListener
+  ) => () => void
+  readonly subscribePresentation: (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: WorkbenchDirectZoomPresentationListener
+  ) => () => void
+}
+
+interface DirectZoomAnchor {
+  readonly screenX: number
+  readonly screenY: number
+  readonly worldX: number
+  readonly worldY: number
+}
+
+interface ActiveDirectZoom {
+  anchor: DirectZoomAnchor
+  deadlineId: number | null
+  frameId: number | null
+  idle: boolean
+  idleTimeoutId: number | null
+  instance: ReactFlowInstance<WorkbenchFlowNode, Edge>
+  lastTimestamp: number
+  presentation: Viewport
+  reducedMotion: boolean
+  requestId: number
+  target: Viewport
+  targetZoomStops: number
+  zoomStops: CriticalSpringAxis
+}
+
+const directZoomResponse = 0.065
+const directZoomIdleMilliseconds = 150
+const maximumDirectZoomRuntime = 600
+const zoomValueSettlement = 0.000_2
+const zoomSpeedSettlement = 0.002
+
+export function createWorkbenchDirectZoomController(
+  scheduler: WorkbenchViewportMotionFrameScheduler
+): WorkbenchDirectZoomController {
+  let activeMotion: ActiveDirectZoom | null = null
+  let latestRequest: {
+    readonly instance: ReactFlowInstance<WorkbenchFlowNode, Edge>
+    readonly requestId: number
+  } | null = null
+  let nextRequestId = 1
+  const completionListeners = new WeakMap<
+    ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    Set<WorkbenchDirectZoomCompletionListener>
+  >()
+  const presentationListeners = new WeakMap<
+    ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    Set<WorkbenchDirectZoomPresentationListener>
+  >()
+
+  const cancelMotionSchedule = (motion: ActiveDirectZoom): void => {
+    if (motion.frameId !== null) {
+      scheduler.cancelFrame(motion.frameId)
+      motion.frameId = null
+    }
+    if (motion.idleTimeoutId !== null) {
+      scheduler.cancelTimeout(motion.idleTimeoutId)
+      motion.idleTimeoutId = null
+    }
+    if (motion.deadlineId !== null) {
+      scheduler.cancelTimeout(motion.deadlineId)
+      motion.deadlineId = null
+    }
+  }
+
+  const cancel = (instance?: ReactFlowInstance<WorkbenchFlowNode, Edge>): void => {
+    if (activeMotion && (!instance || activeMotion.instance === instance)) {
+      cancelMotionSchedule(activeMotion)
+      activeMotion = null
+    }
+    if (latestRequest && (!instance || latestRequest.instance === instance)) {
+      latestRequest = null
+    }
+  }
+
+  const subscribe = (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: WorkbenchDirectZoomCompletionListener
+  ): (() => void) => {
+    const listeners = completionListeners.get(instance) ?? new Set()
+    listeners.add(listener)
+    completionListeners.set(instance, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) completionListeners.delete(instance)
+    }
+  }
+
+  const subscribePresentation = (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: WorkbenchDirectZoomPresentationListener
+  ): (() => void) => {
+    const listeners = presentationListeners.get(instance) ?? new Set()
+    listeners.add(listener)
+    presentationListeners.set(instance, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) presentationListeners.delete(instance)
+    }
+  }
+
+  const isLatestRequest = (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    requestId: number
+  ): boolean => latestRequest?.instance === instance && latestRequest.requestId === requestId
+
+  const applyPresentation = (motion: ActiveDirectZoom, viewport: Viewport): Promise<boolean> => {
+    const requestId = motion.requestId
+    return applyViewport(motion.instance, viewport).then((applied) => {
+      if (applied && isLatestRequest(motion.instance, requestId)) {
+        presentationListeners.get(motion.instance)?.forEach((listener) => listener(viewport))
+      }
+      return applied
+    })
+  }
+
+  const finishMotion = (motion: ActiveDirectZoom): void => {
+    if (activeMotion !== motion || !isLatestRequest(motion.instance, motion.requestId)) return
+
+    cancelMotionSchedule(motion)
+    activeMotion = null
+    void applyPresentation(motion, motion.target).then((applied) => {
+      if (!applied || !isLatestRequest(motion.instance, motion.requestId)) return
+      latestRequest = null
+      completionListeners
+        .get(motion.instance)
+        ?.forEach((listener) => listener({ viewport: motion.target }))
+    })
+  }
+
+  const scheduleNextFrame = (motion: ActiveDirectZoom): void => {
+    if (activeMotion !== motion || motion.frameId !== null || motion.reducedMotion) return
+    motion.frameId = scheduler.requestFrame(advanceMotion)
+  }
+
+  const isMotionSettled = (motion: ActiveDirectZoom): boolean => {
+    const targetZoom = motion.target.zoom
+    return isCriticalSpringAxisSettled(motion.zoomStops, motion.targetZoomStops, {
+      speed: zoomSpeedSettlement / (targetZoom * Math.LN2),
+      value: zoomValueSettlement / (targetZoom * Math.LN2)
+    })
+  }
+
+  const advanceMotion = (timestamp: number): void => {
+    const motion = activeMotion
+    if (!motion) return
+
+    motion.frameId = null
+    const deltaSeconds = Math.max(0, (timestamp - motion.lastTimestamp) / 1_000)
+    motion.lastTimestamp = timestamp
+    motion.zoomStops = advanceCriticalSpringAxis(
+      motion.zoomStops,
+      motion.targetZoomStops,
+      directZoomResponse,
+      deltaSeconds
+    )
+    motion.presentation = resolveAnchoredViewport(motion.anchor, 2 ** motion.zoomStops.value)
+    void applyPresentation(motion, motion.presentation)
+
+    if (isMotionSettled(motion)) {
+      if (motion.idle) finishMotion(motion)
+      return
+    }
+    scheduleNextFrame(motion)
+  }
+
+  const scheduleGestureEnd = (motion: ActiveDirectZoom): void => {
+    if (motion.idleTimeoutId !== null) scheduler.cancelTimeout(motion.idleTimeoutId)
+    if (motion.deadlineId !== null) scheduler.cancelTimeout(motion.deadlineId)
+
+    motion.idleTimeoutId = scheduler.requestTimeout(() => {
+      if (activeMotion !== motion) return
+      motion.idleTimeoutId = null
+      motion.idle = true
+      if (motion.reducedMotion || isMotionSettled(motion)) {
+        finishMotion(motion)
+      } else {
+        scheduleNextFrame(motion)
+      }
+    }, directZoomIdleMilliseconds)
+    motion.deadlineId = scheduler.requestTimeout(() => {
+      if (activeMotion !== motion) return
+      motion.deadlineId = null
+      finishMotion(motion)
+    }, directZoomIdleMilliseconds + maximumDirectZoomRuntime)
+  }
+
+  const retarget = (
+    instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    input: WorkbenchDirectZoomInput
+  ): boolean => {
+    const continuingMotion = activeMotion?.instance === instance ? activeMotion : null
+    const started = !continuingMotion
+    const restartFrameClock = !continuingMotion || continuingMotion.frameId === null
+    const now = scheduler.now()
+    const currentViewport = continuingMotion?.presentation ?? instance.getViewport()
+    const currentZoomStops = Math.log2(currentViewport.zoom)
+    const baseTargetZoomStops = continuingMotion?.targetZoomStops ?? currentZoomStops
+    const targetZoomStops = clampZoomStops(baseTargetZoomStops + input.deltaZoomStops)
+    const anchor = resolveDirectZoomAnchor(currentViewport, input.anchor)
+    const target = resolveAnchoredViewport(anchor, 2 ** targetZoomStops)
+    const requestId = nextRequestId
+    nextRequestId += 1
+
+    if (!continuingMotion) cancel()
+
+    const motion: ActiveDirectZoom = continuingMotion ?? {
+      anchor,
+      deadlineId: null,
+      frameId: null,
+      idle: false,
+      idleTimeoutId: null,
+      instance,
+      lastTimestamp: now,
+      presentation: currentViewport,
+      reducedMotion: input.reducedMotion,
+      requestId,
+      target,
+      targetZoomStops,
+      zoomStops: { value: currentZoomStops, velocity: 0 }
+    }
+
+    motion.anchor = anchor
+    motion.idle = false
+    if (restartFrameClock) motion.lastTimestamp = now
+    motion.presentation = currentViewport
+    motion.reducedMotion = input.reducedMotion
+    motion.requestId = requestId
+    motion.target = target
+    motion.targetZoomStops = targetZoomStops
+    motion.zoomStops = { ...motion.zoomStops, value: currentZoomStops }
+    activeMotion = motion
+    latestRequest = { instance, requestId }
+
+    if (input.reducedMotion) {
+      if (motion.frameId !== null) {
+        scheduler.cancelFrame(motion.frameId)
+        motion.frameId = null
+      }
+      motion.presentation = target
+      motion.zoomStops = { value: targetZoomStops, velocity: 0 }
+      void applyPresentation(motion, target)
+    } else {
+      scheduleNextFrame(motion)
+    }
+    scheduleGestureEnd(motion)
+
+    return started
+  }
+
+  return { cancel, retarget, subscribe, subscribePresentation }
+}
+
+function resolveDirectZoomAnchor(
+  viewport: Viewport,
+  screen: { readonly x: number; readonly y: number }
+): DirectZoomAnchor {
+  return {
+    screenX: screen.x,
+    screenY: screen.y,
+    worldX: (screen.x - viewport.x) / viewport.zoom,
+    worldY: (screen.y - viewport.y) / viewport.zoom
+  }
+}
+
+function resolveAnchoredViewport(anchor: DirectZoomAnchor, zoom: number): Viewport {
+  return {
+    x: anchor.screenX - anchor.worldX * zoom,
+    y: anchor.screenY - anchor.worldY * zoom,
+    zoom
+  }
+}
+
+function clampZoomStops(zoomStops: number): number {
+  return Math.min(Math.log2(maximumCanvasZoom), Math.max(Math.log2(minimumCanvasZoom), zoomStops))
+}
+
+async function applyViewport(
+  instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+  viewport: Viewport
+): Promise<boolean> {
+  try {
+    return (await instance.setViewport(viewport, { duration: 0 })) !== false
+  } catch {
+    return false
+  }
+}
+
+const browserDirectZoomController = createWorkbenchDirectZoomController(
+  browserViewportMotionFrameScheduler
+)
+
+export function retargetWorkbenchDirectZoom(
+  instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+  input: WorkbenchDirectZoomInput
+): boolean {
+  return browserDirectZoomController.retarget(instance, input)
+}
+
+export function cancelWorkbenchDirectZoom(
+  instance?: ReactFlowInstance<WorkbenchFlowNode, Edge>
+): void {
+  browserDirectZoomController.cancel(instance)
+}
+
+export function subscribeWorkbenchDirectZoomCompletion(
+  instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+  listener: WorkbenchDirectZoomCompletionListener
+): () => void {
+  return browserDirectZoomController.subscribe(instance, listener)
+}
+
+export function subscribeWorkbenchDirectZoomPresentation(
+  instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+  listener: WorkbenchDirectZoomPresentationListener
+): () => void {
+  return browserDirectZoomController.subscribePresentation(instance, listener)
+}

--- a/src/presentation/app-shell/workbenchViewportMotion.ts
+++ b/src/presentation/app-shell/workbenchViewportMotion.ts
@@ -36,6 +36,7 @@ import {
   prefersReducedMotion,
   type WorkbenchViewportMotionFrameScheduler
 } from './workbenchViewportMotionEnvironment'
+import { cancelWorkbenchDirectZoom } from './workbenchDirectZoom'
 
 export { prefersReducedMotion } from './workbenchViewportMotionEnvironment'
 
@@ -557,6 +558,7 @@ export function transitionWorkbenchViewport(
   instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
   command: WorkbenchViewportCommand
 ): Promise<boolean> {
+  cancelWorkbenchDirectZoom(instance)
   return browserViewportMotionController.transition(instance, command)
 }
 

--- a/tests/e2e/canvas-selection-viewport.e2e.spec.ts
+++ b/tests/e2e/canvas-selection-viewport.e2e.spec.ts
@@ -90,6 +90,49 @@ describe('canvas selection viewport e2e', () => {
     },
     electronScenarioTimeoutMs
   )
+
+  it(
+    'smoothly zooms around the real wheel pointer anchor along one continuous curve',
+    async () => {
+      await expectDesktopRuntime(page)
+      await page.getByRole('button', { name: '添加项目' }).click()
+      await page.getByRole('button', { name: '新建终端积木' }).click()
+
+      const node = page.locator('[data-terminal-block-id]').filter({ hasText: 'Terminal 1' })
+      await node.waitFor()
+      const pane = page.locator('.react-flow__pane')
+      await clickTrueCanvasPane(page, pane)
+      await pollCanvasPresentation(
+        page,
+        node,
+        (presentation) =>
+          isNear(presentation.zoom, 0.35, 0.000_1) && isCanvasNodeCentered(presentation)
+      )
+
+      const anchor = await resolveTrueCanvasPanePoint(pane)
+      const initialPresentation = await readPointerZoomPresentation(page, anchor)
+      await beginPointerZoomSampling(page, anchor)
+      await page.mouse.move(anchor.x, anchor.y)
+      await page.mouse.wheel(0, -160)
+
+      const finalPresentation = await pollUntilState({
+        accept: (presentation) =>
+          presentation.zoom > initialPresentation.zoom &&
+          presentation.zoomLabel === `${Math.round(presentation.zoom * 100)}%`,
+        description: 'canvas wheel zoom to settle and publish its final level',
+        observe: async () => ({
+          ...(await readPointerZoomPresentation(page, anchor)),
+          zoomLabel: await page.getByLabel('画布缩放比例').textContent()
+        }),
+        timeoutMs: 5_000
+      })
+      const presentations = await finishPointerZoomSampling(page)
+
+      expect(finalPresentation.zoom).toBeGreaterThan(initialPresentation.zoom)
+      expectContinuousPointerZoomCurve(presentations, initialPresentation, finalPresentation)
+    },
+    electronScenarioTimeoutMs
+  )
 })
 
 interface CanvasPresentation {
@@ -99,7 +142,15 @@ interface CanvasPresentation {
 }
 
 async function clickTrueCanvasPane(page: Page, pane: Locator): Promise<void> {
-  const point = await pane.evaluate((element) => {
+  const point = await resolveTrueCanvasPanePoint(pane)
+
+  await page.mouse.click(point.x, point.y)
+}
+
+function resolveTrueCanvasPanePoint(
+  pane: Locator
+): Promise<{ readonly x: number; readonly y: number }> {
+  return pane.evaluate((element) => {
     const bounds = element.getBoundingClientRect()
     const fractions = [0.08, 0.2, 0.8, 0.92]
 
@@ -113,8 +164,6 @@ async function clickTrueCanvasPane(page: Page, pane: Locator): Promise<void> {
 
     throw new Error('No unobstructed canvas pane point is available.')
   })
-
-  await page.mouse.click(point.x, point.y)
 }
 
 function pollCanvasPresentation(
@@ -259,5 +308,108 @@ function expectSmoothAnchoredZoom(
   presentations.slice(1).forEach((presentation, index) => {
     const previous = presentations[index]
     expect((presentation.zoom - previous.zoom) * direction).toBeGreaterThanOrEqual(-0.000_1)
+  })
+}
+
+interface PointerZoomPresentation {
+  readonly anchorWorldX: number
+  readonly anchorWorldY: number
+  readonly zoom: number
+}
+
+function readPointerZoomPresentation(
+  page: Page,
+  anchor: { readonly x: number; readonly y: number }
+): Promise<PointerZoomPresentation> {
+  return page.evaluate((screenAnchor) => {
+    const canvas = document.querySelector<HTMLElement>('.react-flow')
+    const viewport = document.querySelector<HTMLElement>('.react-flow__viewport')
+    if (!canvas || !viewport) throw new Error('Canvas zoom presentation is unavailable.')
+
+    const bounds = canvas.getBoundingClientRect()
+    const transform = new DOMMatrixReadOnly(getComputedStyle(viewport).transform)
+    const localX = screenAnchor.x - bounds.left
+    const localY = screenAnchor.y - bounds.top
+
+    return {
+      anchorWorldX: (localX - transform.e) / transform.a,
+      anchorWorldY: (localY - transform.f) / transform.a,
+      zoom: transform.a
+    }
+  }, anchor)
+}
+
+async function beginPointerZoomSampling(
+  page: Page,
+  anchor: { readonly x: number; readonly y: number }
+): Promise<void> {
+  await page.evaluate((screenAnchor) => {
+    const samplingWindow = window as typeof window & {
+      pointerZoomSampling?: {
+        observer: MutationObserver
+        presentations: PointerZoomPresentation[]
+      }
+    }
+    const canvas = document.querySelector<HTMLElement>('.react-flow')
+    const viewport = document.querySelector<HTMLElement>('.react-flow__viewport')
+    if (!canvas || !viewport) throw new Error('Canvas zoom presentation is unavailable.')
+
+    const presentations: PointerZoomPresentation[] = []
+    const sample = () => {
+      const bounds = canvas.getBoundingClientRect()
+      const transform = new DOMMatrixReadOnly(getComputedStyle(viewport).transform)
+      const localX = screenAnchor.x - bounds.left
+      const localY = screenAnchor.y - bounds.top
+      presentations.push({
+        anchorWorldX: (localX - transform.e) / transform.a,
+        anchorWorldY: (localY - transform.f) / transform.a,
+        zoom: transform.a
+      })
+    }
+    const observer = new MutationObserver(sample)
+    observer.observe(viewport, { attributeFilter: ['style'], attributes: true })
+    samplingWindow.pointerZoomSampling = { observer, presentations }
+    sample()
+  }, anchor)
+}
+
+function finishPointerZoomSampling(page: Page): Promise<PointerZoomPresentation[]> {
+  return page.evaluate(() => {
+    const samplingWindow = window as typeof window & {
+      pointerZoomSampling?: {
+        observer: MutationObserver
+        presentations: PointerZoomPresentation[]
+      }
+    }
+    const sampling = samplingWindow.pointerZoomSampling
+    if (!sampling) throw new Error('Canvas pointer zoom sampling was not started.')
+
+    sampling.observer.disconnect()
+    delete samplingWindow.pointerZoomSampling
+    return sampling.presentations
+  })
+}
+
+function expectContinuousPointerZoomCurve(
+  presentations: PointerZoomPresentation[],
+  initialPresentation: PointerZoomPresentation,
+  finalPresentation: PointerZoomPresentation
+): void {
+  const movingPresentations = presentations.filter(
+    (presentation) => Math.abs(presentation.zoom - initialPresentation.zoom) > 0.000_1
+  )
+
+  expect(movingPresentations.length).toBeGreaterThan(0)
+  expect(movingPresentations.length).toBeGreaterThan(2)
+  expect(movingPresentations[0].zoom).toBeLessThan(finalPresentation.zoom - 0.000_1)
+  presentations.forEach((presentation) => {
+    const anchorDrift = Math.hypot(
+      (presentation.anchorWorldX - initialPresentation.anchorWorldX) * presentation.zoom,
+      (presentation.anchorWorldY - initialPresentation.anchorWorldY) * presentation.zoom
+    )
+    expect(anchorDrift).toBeLessThan(0.75)
+  })
+  presentations.slice(1).forEach((presentation, index) => {
+    expect(presentation.zoom).toBeGreaterThanOrEqual(presentations[index].zoom - 0.000_1)
   })
 }

--- a/tests/unit/presentation/canvas-minimap.spec.tsx
+++ b/tests/unit/presentation/canvas-minimap.spec.tsx
@@ -14,8 +14,22 @@ import {
 } from '../../../src/presentation/app-shell/types'
 
 const liveViewportMotion = vi.hoisted(() => ({
+  directListener: null as
+    ((viewport: { readonly x: number; readonly y: number; readonly zoom: number }) => void) | null,
   listener: null as
     ((viewport: { readonly x: number; readonly y: number; readonly zoom: number }) => void) | null
+}))
+
+vi.mock('../../../src/presentation/app-shell/workbenchDirectZoom', () => ({
+  subscribeWorkbenchDirectZoomPresentation: (
+    _instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: (viewport: { readonly x: number; readonly y: number; readonly zoom: number }) => void
+  ) => {
+    liveViewportMotion.directListener = listener
+    return () => {
+      liveViewportMotion.directListener = null
+    }
+  }
 }))
 
 vi.mock('../../../src/presentation/app-shell/workbenchViewportMotion', () => ({
@@ -38,6 +52,7 @@ describe('canvas minimap', () => {
   })
 
   beforeEach(() => {
+    liveViewportMotion.directListener = null
     liveViewportMotion.listener = null
   })
 
@@ -223,6 +238,24 @@ describe('canvas minimap', () => {
     expect(within(viewportControls).getByLabelText('画布缩放比例')).toHaveTextContent('70%')
   })
 
+  it('keeps the zoom level synchronized with live viewport presentations', () => {
+    const instance = {} as ReactFlowInstance<WorkbenchFlowNode, Edge>
+    render(<CanvasMinimap {...createCanvasMinimapProps()} viewportMotionInstance={instance} />)
+
+    const zoomLevel = screen.getByLabelText('画布缩放比例')
+    expect(zoomLevel).toHaveTextContent('100%')
+
+    act(() => {
+      liveViewportMotion.directListener?.({ x: -120, y: 48, zoom: 1.37 })
+    })
+    expect(zoomLevel).toHaveTextContent('137%')
+
+    act(() => {
+      liveViewportMotion.listener?.({ x: -180, y: 72, zoom: 1.25 })
+    })
+    expect(zoomLevel).toHaveTextContent('125%')
+  })
+
   it('keeps the canvas viewport controls available while the minimap is collapsed', () => {
     render(<CanvasMinimap {...createCanvasMinimapProps()} isCollapsed />)
 
@@ -405,6 +438,15 @@ describe('canvas minimap', () => {
     expect(viewportFrame).toHaveAttribute('y', '-38.4')
     expect(viewportFrame).toHaveAttribute('width', '768')
     expect(viewportFrame).toHaveAttribute('height', '512')
+
+    act(() => {
+      liveViewportMotion.directListener?.({ x: -240, y: 96, zoom: 1.5 })
+    })
+
+    expect(viewportFrame).toHaveAttribute('x', '160')
+    expect(viewportFrame).toHaveAttribute('y', '-64')
+    expect(viewportFrame).toHaveAttribute('width', '640')
+    expect(viewportFrame).toHaveAttribute('height', `${640 / 1.5}`)
   })
 })
 

--- a/tests/unit/presentation/canvas-viewport-actions.spec.tsx
+++ b/tests/unit/presentation/canvas-viewport-actions.spec.tsx
@@ -1,11 +1,20 @@
 import { act, renderHook } from '@testing-library/react'
 import type { Edge, ReactFlowInstance } from '@xyflow/react'
+import type * as WorkbenchDirectZoomModule from '../../../src/presentation/app-shell/workbenchDirectZoom'
 
 import type { WorkbenchFlowNode } from '../../../src/presentation/app-shell/types'
 import { useCanvasViewportActions } from '../../../src/presentation/app-shell/useCanvasViewportActions'
 
+const directZoomSpies = vi.hoisted(() => ({ cancel: vi.fn() }))
+
+vi.mock('../../../src/presentation/app-shell/workbenchDirectZoom', async (importOriginal) => ({
+  ...(await importOriginal<typeof WorkbenchDirectZoomModule>()),
+  cancelWorkbenchDirectZoom: directZoomSpies.cancel
+}))
+
 describe('canvas viewport actions', () => {
   beforeEach(() => {
+    directZoomSpies.cancel.mockClear()
     stubReducedMotionPreference()
   })
 
@@ -30,6 +39,7 @@ describe('canvas viewport actions', () => {
     })
 
     expect(onUserAction).toHaveBeenCalledTimes(3)
+    expect(directZoomSpies.cancel).toHaveBeenCalledTimes(3)
     expect(setViewport).toHaveBeenCalledTimes(3)
   })
 

--- a/tests/unit/presentation/workbench-canvas-viewport-subscription.spec.ts
+++ b/tests/unit/presentation/workbench-canvas-viewport-subscription.spec.ts
@@ -1,0 +1,69 @@
+import type { Edge, ReactFlowInstance, Viewport } from '@xyflow/react'
+
+import type { WorkbenchFlowNode } from '../../../src/presentation/app-shell/types'
+import { subscribeCanvasViewportMotionCompletion } from '../../../src/presentation/app-shell/workbenchCanvasViewport'
+
+const motionSubscriptions = vi.hoisted(() => ({
+  directListener: null as ((completion: { readonly viewport: Viewport }) => void) | null,
+  programmaticListener: null as
+    | ((completion: {
+        readonly intent: { readonly type: 'quick' }
+        readonly viewport: Viewport
+      }) => void)
+    | null
+}))
+
+vi.mock('../../../src/presentation/app-shell/workbenchDirectZoom', () => ({
+  subscribeWorkbenchDirectZoomCompletion: (
+    _instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: (completion: { readonly viewport: Viewport }) => void
+  ) => {
+    motionSubscriptions.directListener = listener
+    return vi.fn()
+  }
+}))
+
+vi.mock('../../../src/presentation/app-shell/workbenchViewportMotion', () => ({
+  subscribeWorkbenchViewportMotionCompletion: (
+    _instance: ReactFlowInstance<WorkbenchFlowNode, Edge>,
+    listener: (completion: {
+      readonly intent: { readonly type: 'quick' }
+      readonly viewport: Viewport
+    }) => void
+  ) => {
+    motionSubscriptions.programmaticListener = listener
+    return vi.fn()
+  }
+}))
+
+describe('workbench canvas viewport completion subscription', () => {
+  it('publishes both motion sources through the latest persistence callback', () => {
+    const staleOnViewportChange = vi.fn()
+    const currentOnViewportChange = vi.fn()
+    const onViewportChangeRef = { current: staleOnViewportChange }
+    const setCanvasViewport = vi.fn()
+    const setViewportZoom = vi.fn()
+    const instance = {} as ReactFlowInstance<WorkbenchFlowNode, Edge>
+
+    subscribeCanvasViewportMotionCompletion({
+      instance,
+      onViewportChangeRef,
+      setCanvasViewport,
+      setViewportZoom
+    })
+    onViewportChangeRef.current = currentOnViewportChange
+    motionSubscriptions.programmaticListener?.({
+      intent: { type: 'quick' },
+      viewport: { x: -40, y: 20, zoom: 1.2 }
+    })
+    motionSubscriptions.directListener?.({
+      viewport: { x: -80, y: 40, zoom: 1.3 }
+    })
+
+    expect(staleOnViewportChange).not.toHaveBeenCalled()
+    expect(currentOnViewportChange).toHaveBeenNthCalledWith(1, { x: -40, y: 20, zoom: 1.2 })
+    expect(currentOnViewportChange).toHaveBeenNthCalledWith(2, { x: -80, y: 40, zoom: 1.3 })
+    expect(setCanvasViewport).toHaveBeenCalledTimes(2)
+    expect(setViewportZoom).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/presentation/workbench-canvas.drag-isolation.spec.tsx
+++ b/tests/unit/presentation/workbench-canvas.drag-isolation.spec.tsx
@@ -3,6 +3,7 @@ import type { NodeChange } from '@xyflow/react'
 import type * as ReactFlowModule from '@xyflow/react'
 import type { ReactNode } from 'react'
 import type * as WorkbenchViewportMotionModule from '../../../src/presentation/app-shell/workbenchViewportMotion'
+import type * as WorkbenchDirectZoomModule from '../../../src/presentation/app-shell/workbenchDirectZoom'
 
 import { createAgentConsoleFlowNode } from '../../../src/presentation/app-shell/agentConsoleFlowNode'
 import { createTerminalFlowNodes } from '../../../src/presentation/app-shell/terminalFlowNodes'
@@ -19,6 +20,14 @@ const reactFlowProps = vi.hoisted(() => ({
 }))
 const viewportMotionSpies = vi.hoisted(() => ({
   cancel: vi.fn()
+}))
+const directZoomSpies = vi.hoisted(() => ({
+  cancel: vi.fn()
+}))
+
+vi.mock('../../../src/presentation/app-shell/workbenchDirectZoom', async (importOriginal) => ({
+  ...(await importOriginal<typeof WorkbenchDirectZoomModule>()),
+  cancelWorkbenchDirectZoom: directZoomSpies.cancel
 }))
 
 vi.mock('../../../src/presentation/app-shell/workbenchViewportMotion', async (importOriginal) => ({
@@ -47,6 +56,7 @@ describe('workbench canvas drag isolation', () => {
   beforeEach(() => {
     reactFlowProps.latest = null
     viewportMotionSpies.cancel.mockClear()
+    directZoomSpies.cancel.mockClear()
   })
 
   it('does not move an Agent when dragging a selected terminal', () => {
@@ -142,6 +152,15 @@ describe('workbench canvas drag isolation', () => {
 
     expect(onViewportInteractionStart).toHaveBeenCalledOnce()
     expect(viewportMotionSpies.cancel).toHaveBeenCalledOnce()
+    expect(directZoomSpies.cancel).toHaveBeenCalledOnce()
+  })
+
+  it('leaves wheel zoom to the anchored direct zoom controller', () => {
+    const { agentNode, terminalNode } = createNodes()
+
+    renderCanvas([agentNode, terminalNode], vi.fn())
+
+    expect(reactFlowProps.latest?.zoomOnScroll).toBe(false)
   })
 })
 
@@ -153,6 +172,7 @@ interface MockReactFlowProps {
   readonly onPaneClick?: () => void
   readonly onMoveStart?: (event: MouseEvent | null) => void
   readonly selectionKeyCode?: string | null
+  readonly zoomOnScroll?: boolean
 }
 
 function renderCanvas(

--- a/tests/unit/presentation/workbench-direct-zoom-input.spec.tsx
+++ b/tests/unit/presentation/workbench-direct-zoom-input.spec.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render } from '@testing-library/react'
+import type { Edge, ReactFlowInstance } from '@xyflow/react'
+import { useRef } from 'react'
+
+import type { WorkbenchFlowNode } from '../../../src/presentation/app-shell/types'
+import {
+  resolveWorkbenchWheelZoomStops,
+  useWorkbenchDirectZoom
+} from '../../../src/presentation/app-shell/useWorkbenchDirectZoom'
+import * as directZoom from '../../../src/presentation/app-shell/workbenchDirectZoom'
+import * as viewportMotion from '../../../src/presentation/app-shell/workbenchViewportMotion'
+
+describe('workbench direct zoom input', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    { ctrlKey: false, deltaMode: WheelEvent.DOM_DELTA_PIXEL, deltaY: -100, mac: false, zoom: 0.2 },
+    { ctrlKey: false, deltaMode: WheelEvent.DOM_DELTA_LINE, deltaY: -4, mac: false, zoom: 0.2 },
+    { ctrlKey: false, deltaMode: WheelEvent.DOM_DELTA_PAGE, deltaY: -0.2, mac: false, zoom: 0.2 },
+    { ctrlKey: true, deltaMode: WheelEvent.DOM_DELTA_PIXEL, deltaY: -10, mac: true, zoom: 0.2 }
+  ])('normalizes wheel input into zoom stops: $deltaMode', (input) => {
+    expect(resolveWorkbenchWheelZoomStops(input)).toBeCloseTo(input.zoom, 10)
+  })
+
+  it('captures pane wheel input once and leaves nowheel content in control', () => {
+    const instance = createViewportInstance()
+    const onViewportInteractionStart = vi.fn()
+    const retarget = vi.spyOn(directZoom, 'retargetWorkbenchDirectZoom').mockReturnValue(true)
+    const cancelProgrammatic = vi
+      .spyOn(viewportMotion, 'cancelWorkbenchViewportMotion')
+      .mockImplementation(() => undefined)
+    const view = render(
+      <DirectZoomHarness
+        instance={instance}
+        onViewportInteractionStart={onViewportInteractionStart}
+      />
+    )
+    const pane = view.getByTestId('pane')
+    const terminal = view.getByTestId('terminal')
+
+    const paneEventAccepted = fireEvent.wheel(pane, {
+      clientX: 140,
+      clientY: 90,
+      deltaMode: 0,
+      deltaY: -100
+    })
+    fireEvent.wheel(terminal, { deltaMode: 0, deltaY: -100 })
+    const terminalPinchAccepted = fireEvent.wheel(terminal, {
+      ctrlKey: true,
+      deltaMode: 0,
+      deltaY: -10
+    })
+
+    expect(paneEventAccepted).toBe(false)
+    expect(terminalPinchAccepted).toBe(false)
+    expect(cancelProgrammatic).toHaveBeenCalledOnce()
+    expect(retarget).toHaveBeenCalledOnce()
+    expect(retarget).toHaveBeenCalledWith(instance, {
+      anchor: { x: 120, y: 80 },
+      deltaZoomStops: 0.2,
+      reducedMotion: false
+    })
+    expect(onViewportInteractionStart).toHaveBeenCalledOnce()
+  })
+})
+
+function DirectZoomHarness({
+  instance,
+  onViewportInteractionStart
+}: {
+  readonly instance: ReactFlowInstance<WorkbenchFlowNode, Edge>
+  readonly onViewportInteractionStart: () => void
+}) {
+  const canvasSurfaceRef = useRef<HTMLDivElement | null>(null)
+  const reactFlowInstanceRef = useRef(instance)
+
+  useWorkbenchDirectZoom({
+    canvasSurfaceRef,
+    onViewportInteractionStart,
+    reactFlowInstanceRef,
+    viewportMotionInstance: instance
+  })
+
+  return (
+    <div ref={canvasSurfaceRef}>
+      <div
+        className="react-flow__renderer"
+        ref={(element) => {
+          if (!element) return
+          element.getBoundingClientRect = () =>
+            ({ left: 20, top: 10, width: 960, height: 640 }) as DOMRect
+        }}
+      >
+        <div data-testid="pane" style={{ position: 'absolute', left: 140, top: 90 }} />
+        <div className="nowheel" data-testid="terminal" />
+      </div>
+    </div>
+  )
+}
+
+function createViewportInstance(): ReactFlowInstance<WorkbenchFlowNode, Edge> {
+  return {
+    getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+    setViewport: vi.fn(async () => true)
+  } as unknown as ReactFlowInstance<WorkbenchFlowNode, Edge>
+}

--- a/tests/unit/presentation/workbench-direct-zoom.spec.ts
+++ b/tests/unit/presentation/workbench-direct-zoom.spec.ts
@@ -1,0 +1,405 @@
+import type { Edge, ReactFlowInstance, Viewport } from '@xyflow/react'
+
+import type { WorkbenchFlowNode } from '../../../src/presentation/app-shell/types'
+import { createWorkbenchDirectZoomController } from '../../../src/presentation/app-shell/workbenchDirectZoom'
+
+describe('workbench direct zoom controller', () => {
+  it('follows one continuous time-based curve at 60Hz and 120Hz', () => {
+    const sixtyHertzFrames = new TestFrameScheduler()
+    const hundredTwentyHertzFrames = new TestFrameScheduler()
+    const sixtyHertzController = createWorkbenchDirectZoomController(sixtyHertzFrames)
+    const hundredTwentyHertzController =
+      createWorkbenchDirectZoomController(hundredTwentyHertzFrames)
+    const sixtyHertzInstance = createViewportInstance()
+    const hundredTwentyHertzInstance = createViewportInstance()
+    const input = {
+      anchor: { x: 320, y: 240 },
+      deltaZoomStops: 0.25,
+      reducedMotion: false
+    }
+
+    sixtyHertzController.retarget(sixtyHertzInstance.value, input)
+    hundredTwentyHertzController.retarget(hundredTwentyHertzInstance.value, input)
+    sixtyHertzFrames.step(1_000 / 60)
+    hundredTwentyHertzFrames.step(1_000 / 120)
+    hundredTwentyHertzFrames.step(1_000 / 120)
+
+    const targetZoomStops = 0.25
+    const sixtyHertzZoomStops = Math.log2(sixtyHertzInstance.viewport.zoom)
+    const hundredTwentyHertzZoomStops = Math.log2(hundredTwentyHertzInstance.viewport.zoom)
+    expect(sixtyHertzZoomStops / targetZoomStops).toBeGreaterThan(0.35)
+    expect(sixtyHertzZoomStops / targetZoomStops).toBeLessThan(0.7)
+    expect(hundredTwentyHertzZoomStops).toBeCloseTo(sixtyHertzZoomStops, 10)
+    expect(hundredTwentyHertzInstance.viewport.x).toBeCloseTo(sixtyHertzInstance.viewport.x, 10)
+    expect(hundredTwentyHertzInstance.viewport.y).toBeCloseTo(sixtyHertzInstance.viewport.y, 10)
+    expect(sixtyHertzInstance.value.setViewport).toHaveBeenCalledTimes(1)
+    expect(hundredTwentyHertzInstance.value.setViewport).toHaveBeenCalledTimes(2)
+
+    sixtyHertzFrames.finish()
+    hundredTwentyHertzFrames.finish()
+    expect(sixtyHertzInstance.viewport.zoom).toBeCloseTo(2 ** targetZoomStops, 3)
+    expect(hundredTwentyHertzInstance.viewport.zoom).toBeCloseTo(2 ** targetZoomStops, 3)
+    sixtyHertzController.cancel()
+    hundredTwentyHertzController.cancel()
+  })
+
+  it('does not restart the frame clock when wheel events outpace presentation frames', () => {
+    const burstFrames = new TestFrameScheduler()
+    const coalescedFrames = new TestFrameScheduler()
+    const burstController = createWorkbenchDirectZoomController(burstFrames)
+    const coalescedController = createWorkbenchDirectZoomController(coalescedFrames)
+    const burstInstance = createViewportInstance()
+    const coalescedInstance = createViewportInstance()
+    const input = {
+      anchor: { x: 320, y: 240 },
+      reducedMotion: false
+    }
+
+    burstController.retarget(burstInstance.value, { ...input, deltaZoomStops: 0.1 })
+    for (let eventIndex = 0; eventIndex < 3; eventIndex += 1) {
+      burstFrames.elapseWithoutFrames(4)
+      burstController.retarget(burstInstance.value, { ...input, deltaZoomStops: 0.1 })
+    }
+    burstFrames.step(1_000 / 60 - 12)
+
+    coalescedController.retarget(coalescedInstance.value, {
+      ...input,
+      deltaZoomStops: 0.4
+    })
+    coalescedFrames.step(1_000 / 60)
+
+    expect(burstInstance.viewport.zoom).toBeCloseTo(coalescedInstance.viewport.zoom, 10)
+    expect(burstInstance.viewport.x).toBeCloseTo(coalescedInstance.viewport.x, 10)
+    expect(burstInstance.viewport.y).toBeCloseTo(coalescedInstance.viewport.y, 10)
+    burstController.cancel()
+    coalescedController.cancel()
+  })
+
+  it('coalesces a wheel burst into one continuous motion while keeping the pointer world anchor fixed', async () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createViewportInstance({ x: 80, y: -40, zoom: 1 })
+    const anchor = { x: 320, y: 220 }
+    const worldAnchor = {
+      x: (anchor.x - instance.viewport.x) / instance.viewport.zoom,
+      y: (anchor.y - instance.viewport.y) / instance.viewport.zoom
+    }
+    const presentations: Viewport[] = []
+    const completions: Viewport[] = []
+
+    controller.subscribePresentation(instance.value, (viewport) => presentations.push(viewport))
+    controller.subscribe(instance.value, ({ viewport }) => completions.push(viewport))
+
+    expect(
+      controller.retarget(instance.value, {
+        anchor,
+        deltaZoomStops: 0.1,
+        reducedMotion: false
+      })
+    ).toBe(true)
+    expect(
+      controller.retarget(instance.value, {
+        anchor,
+        deltaZoomStops: 0.1,
+        reducedMotion: false
+      })
+    ).toBe(false)
+
+    expect(instance.viewport.zoom).toBe(1)
+    expect(instance.value.setViewport).not.toHaveBeenCalled()
+    expect(frames.pendingCount).toBe(1)
+
+    frames.step()
+    await vi.waitFor(() => expect(presentations).toHaveLength(1))
+
+    expect(Math.log2(instance.viewport.zoom)).toBeGreaterThan(0.07)
+    expect(Math.log2(instance.viewport.zoom)).toBeLessThan(0.14)
+    expect(instance.viewport.zoom).toBeLessThan(2 ** 0.2)
+    expect(instance.value.setViewport).toHaveBeenCalledTimes(1)
+    expect(completions).toEqual([])
+
+    frames.finish()
+    frames.elapseWithoutFrames(150)
+    await vi.waitFor(() => expect(completions).toHaveLength(1))
+
+    expect(instance.viewport.zoom).toBeCloseTo(2 ** 0.2, 10)
+    expect(presentations.length).toBeGreaterThan(2)
+    presentations.forEach((viewport) => {
+      expect((anchor.x - viewport.x) / viewport.zoom).toBeCloseTo(worldAnchor.x, 10)
+      expect((anchor.y - viewport.y) / viewport.zoom).toBeCloseTo(worldAnchor.y, 10)
+    })
+    expect(completions).toEqual([instance.viewport])
+  })
+
+  it('preserves presentation velocity when wheel input reverses', () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createViewportInstance()
+    const input = {
+      anchor: { x: 480, y: 320 },
+      reducedMotion: false
+    }
+
+    controller.retarget(instance.value, { ...input, deltaZoomStops: 0.5 })
+    frames.step()
+    const zoomBeforeReversal = Math.log2(instance.viewport.zoom)
+
+    controller.retarget(instance.value, { ...input, deltaZoomStops: -0.3 })
+    frames.step()
+    const zoomAfterReversal = Math.log2(instance.viewport.zoom)
+
+    expect(zoomAfterReversal).toBeGreaterThan(zoomBeforeReversal)
+    frames.finish()
+    expect(instance.viewport.zoom).toBeCloseTo(2 ** 0.2, 3)
+    controller.cancel()
+  })
+
+  it('clamps every delta mode to the shared canvas zoom bounds', async () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const maximumInstance = createViewportInstance({ x: 0, y: 0, zoom: 1.55 })
+    const minimumInstance = createViewportInstance({ x: 0, y: 0, zoom: 0.36 })
+
+    controller.retarget(maximumInstance.value, {
+      anchor: { x: 400, y: 300 },
+      deltaZoomStops: 4,
+      reducedMotion: true
+    })
+    frames.elapseWithoutFrames(150)
+    await vi.waitFor(() => expect(maximumInstance.viewport.zoom).toBe(1.6))
+
+    controller.retarget(minimumInstance.value, {
+      anchor: { x: 400, y: 300 },
+      deltaZoomStops: -4,
+      reducedMotion: true
+    })
+    frames.elapseWithoutFrames(150)
+    await vi.waitFor(() => expect(minimumInstance.viewport.zoom).toBe(0.35))
+  })
+
+  it('applies reduced motion immediately but commits only once after the wheel burst ends', async () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createViewportInstance()
+    const completions: Viewport[] = []
+
+    controller.subscribe(instance.value, ({ viewport }) => completions.push(viewport))
+    controller.retarget(instance.value, {
+      anchor: { x: 300, y: 200 },
+      deltaZoomStops: 0.1,
+      reducedMotion: true
+    })
+    const firstTarget = instance.viewport.zoom
+    controller.retarget(instance.value, {
+      anchor: { x: 300, y: 200 },
+      deltaZoomStops: 0.1,
+      reducedMotion: true
+    })
+
+    expect(instance.viewport.zoom).toBeGreaterThan(firstTarget)
+    expect(completions).toEqual([])
+    expect(frames.pendingCount).toBe(0)
+
+    frames.elapseWithoutFrames(149)
+    expect(completions).toEqual([])
+    frames.elapseWithoutFrames(1)
+    await vi.waitFor(() => expect(completions).toEqual([instance.viewport]))
+  })
+
+  it('cancels at the current presentation without a late completion', () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createViewportInstance()
+    const completions = vi.fn()
+
+    controller.subscribe(instance.value, completions)
+    controller.retarget(instance.value, {
+      anchor: { x: 480, y: 320 },
+      deltaZoomStops: 0.5,
+      reducedMotion: false
+    })
+    frames.step()
+    const presentation = instance.viewport
+    controller.cancel(instance.value)
+    frames.elapseWithoutFrames(2_000)
+    frames.finish()
+
+    expect(instance.viewport).toEqual(presentation)
+    expect(completions).not.toHaveBeenCalled()
+    expect(frames.pendingCount).toBe(0)
+    expect(frames.pendingTimeoutCount).toBe(0)
+  })
+
+  it('suppresses an asynchronously applied presentation from an older wheel target', async () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createDeferredViewportInstance()
+    const presentations: Viewport[] = []
+    const completions: Viewport[] = []
+
+    controller.subscribePresentation(instance.value, (viewport) => presentations.push(viewport))
+    controller.subscribe(instance.value, ({ viewport }) => completions.push(viewport))
+    controller.retarget(instance.value, {
+      anchor: { x: 320, y: 240 },
+      deltaZoomStops: 0.1,
+      reducedMotion: true
+    })
+    controller.retarget(instance.value, {
+      anchor: { x: 320, y: 240 },
+      deltaZoomStops: 0.1,
+      reducedMotion: true
+    })
+
+    instance.applications[0]?.complete(true)
+    await Promise.resolve()
+    expect(presentations).toEqual([])
+
+    instance.applications[1]?.complete(true)
+    await vi.waitFor(() => expect(presentations).toEqual([instance.applications[1]?.viewport]))
+    frames.elapseWithoutFrames(150)
+    expect(completions).toEqual([])
+
+    instance.applications[2]?.complete(true)
+    await vi.waitFor(() => expect(completions).toEqual([instance.applications[2]?.viewport]))
+  })
+
+  it('commits the exact target when animation frames stop arriving', async () => {
+    const frames = new TestFrameScheduler()
+    const controller = createWorkbenchDirectZoomController(frames)
+    const instance = createViewportInstance()
+    const completions: Viewport[] = []
+
+    controller.subscribe(instance.value, ({ viewport }) => completions.push(viewport))
+    controller.retarget(instance.value, {
+      anchor: { x: 480, y: 320 },
+      deltaZoomStops: 0.25,
+      reducedMotion: false
+    })
+    frames.step()
+    frames.elapseWithoutFrames(1_350)
+
+    await vi.waitFor(() => expect(completions).toEqual([instance.viewport]))
+    expect(instance.viewport.zoom).toBeCloseTo(2 ** 0.25, 10)
+    expect(frames.pendingCount).toBe(0)
+    expect(frames.pendingTimeoutCount).toBe(0)
+  })
+})
+
+function createViewportInstance(initialViewport: Viewport = { x: 0, y: 0, zoom: 1 }) {
+  let viewport = initialViewport
+  const value = {
+    getViewport: () => viewport,
+    setViewport: vi.fn(async (nextViewport: Viewport) => {
+      viewport = nextViewport
+      return true
+    })
+  } as unknown as ReactFlowInstance<WorkbenchFlowNode, Edge>
+
+  return {
+    get viewport() {
+      return viewport
+    },
+    value
+  }
+}
+
+function createDeferredViewportInstance(): {
+  readonly applications: Array<{
+    readonly complete: (applied: boolean) => void
+    readonly viewport: Viewport
+  }>
+  readonly value: ReactFlowInstance<WorkbenchFlowNode, Edge>
+} {
+  let viewport: Viewport = { x: 0, y: 0, zoom: 1 }
+  const applications: Array<{
+    readonly complete: (applied: boolean) => void
+    readonly viewport: Viewport
+  }> = []
+  const value = {
+    getViewport: () => viewport,
+    setViewport: (nextViewport: Viewport) => {
+      viewport = nextViewport
+      return new Promise<boolean>((complete) => applications.push({ complete, viewport }))
+    }
+  } as unknown as ReactFlowInstance<WorkbenchFlowNode, Edge>
+
+  return { applications, value }
+}
+
+class TestFrameScheduler {
+  private callbacks = new Map<number, FrameRequestCallback>()
+  private timeoutCallbacks = new Map<
+    number,
+    { readonly callback: () => void; readonly dueAt: number }
+  >()
+  private nextFrameId = 1
+  private nextTimeoutId = 1
+  private timestamp = 0
+
+  readonly cancelFrame = (frameId: number): void => {
+    this.callbacks.delete(frameId)
+  }
+
+  readonly cancelTimeout = (timeoutId: number): void => {
+    this.timeoutCallbacks.delete(timeoutId)
+  }
+
+  readonly now = (): number => this.timestamp
+
+  readonly requestFrame = (callback: FrameRequestCallback): number => {
+    const frameId = this.nextFrameId
+    this.nextFrameId += 1
+    this.callbacks.set(frameId, callback)
+    return frameId
+  }
+
+  readonly requestTimeout = (callback: () => void, delayMilliseconds: number): number => {
+    const timeoutId = this.nextTimeoutId
+    this.nextTimeoutId += 1
+    this.timeoutCallbacks.set(timeoutId, {
+      callback,
+      dueAt: this.timestamp + delayMilliseconds
+    })
+    return timeoutId
+  }
+
+  get pendingCount(): number {
+    return this.callbacks.size
+  }
+
+  get pendingTimeoutCount(): number {
+    return this.timeoutCallbacks.size
+  }
+
+  elapseWithoutFrames(milliseconds: number): void {
+    this.timestamp += milliseconds
+    this.runDueTimeouts()
+  }
+
+  step(milliseconds = 1_000 / 60): void {
+    this.timestamp += milliseconds
+    const callbacks = [...this.callbacks.values()]
+    this.callbacks.clear()
+    callbacks.forEach((callback) => callback(this.timestamp))
+    this.runDueTimeouts()
+  }
+
+  finish(): void {
+    for (let frame = 0; frame < 180 && this.pendingCount > 0; frame += 1) {
+      this.step()
+    }
+    if (this.pendingCount > 0) {
+      throw new Error('Direct zoom spring did not settle within the test frame budget.')
+    }
+  }
+
+  private runDueTimeouts(): void {
+    const dueTimeouts = [...this.timeoutCallbacks.entries()].filter(
+      ([, timeout]) => timeout.dueAt <= this.timestamp
+    )
+    for (const [timeoutId, timeout] of dueTimeouts) {
+      this.timeoutCallbacks.delete(timeoutId)
+      timeout.callback()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- take over wheel and trackpad zoom with one interruptible, pointer-anchored critical spring
- coalesce high-frequency wheel input without restarting the presentation frame clock
- keep the minimap viewport frame and zoom percentage synchronized with live viewport presentations
- persist one final viewport per wheel burst while preserving cancellation and reduced-motion behavior

## Testing
- pnpm pre-commit
- 1476 unit tests passed
- 172 integration tests passed, 6 skipped
- 92 contract tests passed
- 41 Electron E2E tests passed