### PR TITLE
fix(run): isolate terminal provider failures

### DIFF
--- a/src/contexts/run/infrastructure/provider/PersistentTerminalProviderClient.ts
+++ b/src/contexts/run/infrastructure/provider/PersistentTerminalProviderClient.ts
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'node:crypto'
-import { closeSync, existsSync, openSync } from 'node:fs'
+import { closeSync, existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { spawn } from 'node:child_process'
@@ -49,12 +49,16 @@ import { TerminalProviderRpcConnection } from './TerminalProviderRpcConnection'
 import {
   acquireProviderLaunchLock,
   atomicWriteProviderMetadata,
+  createProviderDiagnostics,
+  createProviderUnavailableError as providerUnavailable,
   createProviderEndpoint,
   delayProviderOperation,
   getProviderErrorMessage,
   isApplicationDetachReceipt,
   isProviderProcessAlive,
+  isRuntimeInvalidatingProviderError,
   matchesForegroundJob,
+  openProviderProcessLog,
   providerEndpointAcceptsConnections,
   readProviderMetadata,
   removeStaleProviderMetadata,
@@ -74,6 +78,7 @@ export interface PersistentTerminalProviderClientOptions {
   readonly onBackgroundError?: (error: unknown) => void
   readonly onRuntimeUnavailable?: (error: unknown) => void
   readonly onOutput?: (event: TerminalProcessOutputEvent) => void
+  readonly requestDeadlineMs?: number
 }
 
 export class PersistentTerminalProviderClient
@@ -332,12 +337,7 @@ export class PersistentTerminalProviderClient
   }
 
   getDiagnostics(): TerminalModelDiagnosticsSnapshot {
-    return {
-      modelCount: this.identities.size,
-      attachedViewCount: this.viewCallbacks.size,
-      pendingOutputBytes: 0,
-      lastRestoreDurationMs: 0
-    }
+    return createProviderDiagnostics(this.identities.size, this.viewCallbacks.size)
   }
 
   setRetentionPolicy(sessionId: string, retentionPolicy: TerminalRetentionPolicy): Promise<void> {
@@ -404,7 +404,7 @@ export class PersistentTerminalProviderClient
 
   private async connectOrLaunchProvider(): Promise<TerminalProviderMetadata> {
     await mkdir(this.options.stateDirectory, { mode: 0o700, recursive: true })
-    const metadataPath = this.metadataPath()
+    const metadataPath = join(this.options.stateDirectory, 'provider.json')
     let launchLock = await this.acquireLaunchLock()
     if (!launchLock) {
       try {
@@ -476,7 +476,7 @@ export class PersistentTerminalProviderClient
   }
 
   private acquireLaunchLock() {
-    return acquireProviderLaunchLock(this.launchLockPath())
+    return acquireProviderLaunchLock(join(this.options.stateDirectory, 'provider-launch.lock'))
   }
 
   private async connectMetadata(metadata: TerminalProviderMetadata): Promise<void> {
@@ -484,6 +484,7 @@ export class PersistentTerminalProviderClient
       endpoint: metadata.endpoint,
       authToken: metadata.authToken,
       protocolVersion: metadata.protocolVersion,
+      requestDeadlineMs: this.options.requestDeadlineMs,
       onEvent: (event) => this.handleEvent(event),
       onDisconnect: () => this.handleProviderDisconnect(connection)
     })
@@ -511,8 +512,9 @@ export class PersistentTerminalProviderClient
       }
       await this.claimController(connection)
       connection.instanceId = health.instanceId
-      this.connection?.close()
+      const previousConnection = this.connection
       this.connection = connection
+      previousConnection?.close()
     } catch (error) {
       connection.close()
       throw error
@@ -523,10 +525,7 @@ export class PersistentTerminalProviderClient
     const deadline = Date.now() + providerControllerClaimTimeoutMs
     while (true) {
       try {
-        await connection.request('claimController', {
-          controllerId: this.controllerId,
-          processId: process.pid
-        })
+        await connection.claimController(this.controllerId, process.pid)
         return
       } catch (error) {
         if (!isAppError(error) || error.code !== 'TERMINAL_PROVIDER_CONTROLLER_BUSY') throw error
@@ -553,17 +552,17 @@ export class PersistentTerminalProviderClient
     await atomicWriteProviderMetadata(metadataPath, metadata)
     const logPath = join(this.options.stateDirectory, 'provider.log')
     rotateProviderLog(logPath)
-    const logFd = openSync(logPath, 'a', 0o600)
+    const processLog = openProviderProcessLog(this.options.stateDirectory)
     const child = spawn(
       this.options.executablePath ?? process.execPath,
       [this.options.providerEntryPath, '--metadata', metadataPath],
       {
         detached: true,
         env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
-        stdio: ['ignore', logFd, logFd]
+        stdio: ['ignore', processLog, processLog]
       }
     )
-    closeSync(logFd)
+    closeSync(processLog)
     child.unref()
     if (!child.pid) throw providerUnavailable('Terminal provider process could not be started.')
     const launched = { ...metadata, processId: child.pid }
@@ -633,25 +632,23 @@ export class PersistentTerminalProviderClient
       this.options.onBackgroundError?.(disconnectError)
       this.options.onRuntimeUnavailable?.(disconnectError)
     }
-    for (const [sessionId, callbacks] of this.processCallbacks) {
-      if (this.processEventGate.isPending(sessionId)) continue
-      const scope = this.identities.get(sessionId)
-      if (scope) callbacks.onExit({ scope, sessionId, exitCode: null })
-    }
-    for (const callbacks of this.foregroundJobCallbacks.values()) {
-      callbacks.onExit({
-        generation: callbacks.generation,
-        launchId: callbacks.launchId,
-        sessionId: callbacks.sessionId,
-        exitCode: null
-      })
-    }
-    this.foregroundJobCallbacks.clear()
   }
 
   private async request<T = void>(method: string, params?: unknown): Promise<T> {
-    if (!this.connection) await this.ensureProviderConnection()
-    return this.requireConnection().request<T>(method, params)
+    let connection: TerminalProviderRpcConnection | null = null
+    try {
+      if (!this.connection) await this.ensureProviderConnection()
+      connection = this.requireConnection()
+      return await connection.request<T>(method, params)
+    } catch (error) {
+      if (isRuntimeInvalidatingProviderError(error)) {
+        if (connection && error.code === 'TERMINAL_PROVIDER_UNAVAILABLE') {
+          this.invalidateConnection(connection)
+        }
+        this.options.onRuntimeUnavailable?.(error)
+      }
+      throw error
+    }
   }
 
   private backgroundRequest(method: string, params?: unknown): void {
@@ -663,24 +660,29 @@ export class PersistentTerminalProviderClient
       this.options.onRuntimeUnavailable?.(error)
       return
     }
-    void this.connection
-      .request(method, params)
-      .catch((error) => this.options.onBackgroundError?.(error))
+    const connection = this.connection
+    void connection.request(method, params).catch((error) => {
+      this.options.onBackgroundError?.(error)
+      if (isRuntimeInvalidatingProviderError(error)) {
+        if (error.code === 'TERMINAL_PROVIDER_UNAVAILABLE') {
+          this.invalidateConnection(connection)
+        }
+        this.options.onRuntimeUnavailable?.(error)
+      }
+    })
   }
 
+  private invalidateConnection(connection: TerminalProviderRpcConnection): void {
+    if (this.connection === connection) {
+      this.connection = null
+      this.connectedMetadata = null
+    }
+    connection.close()
+  }
   private requireConnection(): TerminalProviderRpcConnection {
     if (!this.connection) throw providerUnavailable('Terminal provider is not connected.')
     return this.connection
   }
-
-  private metadataPath(): string {
-    return join(this.options.stateDirectory, 'provider.json')
-  }
-
-  private launchLockPath(): string {
-    return join(this.options.stateDirectory, 'provider-launch.lock')
-  }
-
   private clearApplicationReferences(): void {
     this.processCallbacks.clear()
     this.foregroundJobCallbacks.clear()
@@ -692,8 +694,4 @@ export class PersistentTerminalProviderClient
     this.identities.clear()
     this.recoveryIssueHandler = null
   }
-}
-
-function providerUnavailable(message: string) {
-  return createExpectedAppError('TERMINAL_PROVIDER_UNAVAILABLE', message)
 }

--- a/src/contexts/run/infrastructure/provider/PersistentTerminalProviderClientSupport.ts
+++ b/src/contexts/run/infrastructure/provider/PersistentTerminalProviderClientSupport.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { closeSync, existsSync, mkdirSync, openSync } from 'node:fs'
+import { existsSync, mkdirSync, openSync, renameSync, rmSync } from 'node:fs'
 import { mkdir, open, readFile, rename, rm, stat } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
 import { connect } from 'node:net'
@@ -7,6 +7,12 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
 import type { ForegroundJobProcessIdentity } from '../../application/ports/TerminalProcessPort'
+import type { TerminalModelDiagnosticsSnapshot } from '../../application/dto/TerminalModelSnapshot'
+import {
+  createExpectedAppError,
+  isAppError,
+  type AppError
+} from '../../../../shared-kernel/application/errors/AppError'
 import { terminalProviderProtocolVersion } from './TerminalProviderProtocol'
 
 export interface TerminalProviderMetadata {
@@ -140,11 +146,22 @@ export function rotateProviderLog(path: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
   if (!existsSync(path)) return
   try {
-    const descriptor = openSync(path, 'w', 0o600)
-    closeSync(descriptor)
+    for (let index = 3; index >= 1; index -= 1) {
+      const source = index === 1 ? path : `${path}.${index - 1}`
+      const target = `${path}.${index}`
+      if (!existsSync(source)) continue
+      rmSync(target, { force: true })
+      renameSync(source, target)
+    }
   } catch {
     // Provider startup can continue when diagnostics rotation is unavailable.
   }
+}
+
+export function openProviderProcessLog(stateDirectory: string): number {
+  const path = join(stateDirectory, 'provider-process.log')
+  rotateProviderLog(path)
+  return openSync(path, 'a', 0o600)
 }
 
 export async function acquireProviderLaunchLock(
@@ -181,6 +198,24 @@ export function delayProviderOperation(durationMs: number): Promise<void> {
 
 export function getProviderErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+export function createProviderUnavailableError(message: string) {
+  return createExpectedAppError('TERMINAL_PROVIDER_UNAVAILABLE', message)
+}
+
+export function isRuntimeInvalidatingProviderError(error: unknown): error is AppError {
+  return (
+    isAppError(error) &&
+    (error.code === 'TERMINAL_PROVIDER_UNAVAILABLE' || error.code === 'COMMAND_TIMED_OUT')
+  )
+}
+
+export function createProviderDiagnostics(
+  modelCount: number,
+  attachedViewCount: number
+): TerminalModelDiagnosticsSnapshot {
+  return { attachedViewCount, lastRestoreDurationMs: 0, modelCount, pendingOutputBytes: 0 }
 }
 
 function isProviderMetadata(value: unknown): value is TerminalProviderMetadata {

--- a/src/contexts/run/infrastructure/provider/TerminalProviderControllerLifecycle.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderControllerLifecycle.ts
@@ -12,8 +12,8 @@ import type {
 interface TerminalProviderControllerLifecycleOptions {
   readonly createRelease: (releaseId: string) => Promise<TerminalProviderApplicationDetachResult>
   readonly hasLiveSessions: () => boolean
-  readonly hasUnsafeLiveSessions: () => boolean
   readonly isProcessAlive: (processId: number) => boolean
+  readonly releaseDeadlineMs?: number
   readonly log?: (message: string, details?: Readonly<Record<string, unknown>>) => void
   readonly onClaim: () => void
   readonly onIdleWithoutLiveSessions: () => void
@@ -75,7 +75,10 @@ export class TerminalProviderControllerLifecycle {
     if (this.stateValue.kind !== 'active') return null
     const controller = this.stateValue
     const releaseId = randomUUID()
-    const release = this.options.createRelease(releaseId)
+    const release = withReleaseDeadline(
+      this.options.createRelease(releaseId),
+      this.options.releaseDeadlineMs ?? 4_500
+    )
     const controllerRelease: ProviderControllerRelease = {
       socket: controller.socket,
       controllerId: controller.controllerId,
@@ -147,13 +150,6 @@ export class TerminalProviderControllerLifecycle {
     if (this.stateValue.kind !== 'releasing' || this.stateValue.releaseId !== release.releaseId) {
       return
     }
-    if (this.options.hasUnsafeLiveSessions()) {
-      this.log('controller-release-retained-for-safety', {
-        reason: release.reason,
-        releaseId: release.releaseId
-      })
-      return
-    }
     this.stateValue = { kind: 'unclaimed' }
     this.log('controller-released', {
       reason: release.reason,
@@ -165,6 +161,27 @@ export class TerminalProviderControllerLifecycle {
   private log(message: string, details: Readonly<Record<string, unknown>>): void {
     this.options.log?.(message, details)
   }
+}
+
+function withReleaseDeadline<T>(operation: Promise<T>, deadlineMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => {
+        reject(
+          createExpectedAppError(
+            'COMMAND_TIMED_OUT',
+            'Terminal provider controller release exceeded its deadline.'
+          )
+        )
+      },
+      Math.max(1, deadlineMs)
+    )
+    timeout.unref()
+  })
+  return Promise.race([operation, deadline]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
 }
 
 function controllerBusy() {

--- a/src/contexts/run/infrastructure/provider/TerminalProviderProtocol.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderProtocol.ts
@@ -1,8 +1,9 @@
-export const terminalProviderProtocolVersion = 8
-export const terminalProviderMinimumCompatibleProtocolVersion = 7
+export const terminalProviderProtocolVersion = 9
+export const terminalProviderMinimumCompatibleProtocolVersion = 8
 export const terminalProviderApplicationDetachProtocolVersion = 5
 export const terminalProviderMaxFrameBytes = 32 * 1024 * 1024
 export const terminalProviderMaxOutputChunkBytes = 256 * 1024
+export const terminalProviderDefaultRequestDeadlineMs = 30_000
 
 export interface TerminalProviderApplicationDetachReceipt {
   readonly releaseId: string
@@ -23,8 +24,10 @@ export interface TerminalProviderRequest {
   readonly protocolVersion: number
   readonly requestId: string
   readonly authToken: string
+  readonly controllerLeaseId?: string
   readonly method: string
   readonly params?: unknown
+  readonly deadlineMs?: number
 }
 
 export interface TerminalProviderResponse {

--- a/src/contexts/run/infrastructure/provider/TerminalProviderRequestScheduler.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderRequestScheduler.ts
@@ -1,0 +1,78 @@
+import type { TerminalProviderRequest } from './TerminalProviderProtocol'
+
+const maxPendingRequestsPerLane = 1_024
+
+interface RequestLane {
+  pendingCount: number
+  tail: Promise<void>
+}
+
+export class TerminalProviderRequestScheduler {
+  private readonly lanes = new Map<string, RequestLane>()
+
+  schedule(request: TerminalProviderRequest, operation: () => Promise<void>): Promise<void> {
+    const key = resolveRequestLane(request)
+    const current = this.lanes.get(key) ?? { pendingCount: 0, tail: Promise.resolve() }
+    if (current.pendingCount >= maxPendingRequestsPerLane) {
+      return Promise.reject(new Error(`Terminal provider request lane is full: ${key}`))
+    }
+
+    current.pendingCount += 1
+    const scheduled = current.tail.catch(() => undefined).then(operation)
+    current.tail = scheduled
+      .catch(() => undefined)
+      .finally(() => {
+        current.pendingCount -= 1
+        if (current.pendingCount === 0 && this.lanes.get(key) === current) {
+          this.lanes.delete(key)
+        }
+      })
+    this.lanes.set(key, current)
+    return scheduled
+  }
+}
+
+function resolveRequestLane(request: TerminalProviderRequest): string {
+  if (isControlMethod(request.method)) return 'control'
+  if (request.method === 'setScrollbackRows') return 'settings'
+  const sessionId = readSessionId(request.params)
+  return sessionId ? `session:${sessionId}` : `global:${request.method}`
+}
+
+function isControlMethod(method: string): boolean {
+  return (
+    method === 'health' ||
+    method === 'claimController' ||
+    method === 'listSessions' ||
+    method === 'beginApplicationDetach' ||
+    method === 'awaitApplicationDetach' ||
+    method === 'detachApplication'
+  )
+}
+
+function readSessionId(params: unknown): string | null {
+  if (!isRecord(params)) return null
+  if (typeof params.sessionId === 'string') return params.sessionId
+  if (isRecord(params.identity) && typeof params.identity.sessionId === 'string') {
+    return params.identity.sessionId
+  }
+  if (isRecord(params.command)) {
+    if (
+      isRecord(params.command.identity) &&
+      typeof params.command.identity.sessionId === 'string'
+    ) {
+      return params.command.identity.sessionId
+    }
+    if (isRecord(params.command.scope) && typeof params.command.scope.sessionId === 'string') {
+      return params.command.scope.sessionId
+    }
+  }
+  if (isRecord(params.foregroundJob) && typeof params.foregroundJob.sessionId === 'string') {
+    return params.foregroundJob.sessionId
+  }
+  return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/contexts/run/infrastructure/provider/TerminalProviderRpcConnection.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderRpcConnection.ts
@@ -11,13 +11,15 @@ import {
   type TerminalProviderEvent,
   TerminalProviderFrameDecoder,
   type TerminalProviderMessage,
-  type TerminalProviderRequest
+  type TerminalProviderRequest,
+  terminalProviderDefaultRequestDeadlineMs
 } from './TerminalProviderProtocol'
 
-const providerRequestTimeoutMs = 30_000
+const providerRequestDeadlineGraceMs = 100
 
 export class TerminalProviderRpcConnection {
   instanceId = ''
+  private controllerLeaseId: string | undefined
   private readonly pending = new Map<
     string,
     {
@@ -32,6 +34,7 @@ export class TerminalProviderRpcConnection {
     private readonly socket: Socket,
     private readonly authToken: string,
     private readonly protocolVersion: number,
+    private readonly requestDeadlineMs: number,
     private readonly onEvent: (event: TerminalProviderEvent) => void,
     private readonly onDisconnect: () => void
   ) {
@@ -54,6 +57,7 @@ export class TerminalProviderRpcConnection {
     readonly endpoint: string
     readonly authToken: string
     readonly protocolVersion: number
+    readonly requestDeadlineMs?: number
     readonly onEvent: (event: TerminalProviderEvent) => void
     readonly onDisconnect: () => void
   }): Promise<TerminalProviderRpcConnection> {
@@ -66,6 +70,7 @@ export class TerminalProviderRpcConnection {
       socket,
       input.authToken,
       input.protocolVersion,
+      resolveRequestDeadline(input.requestDeadlineMs),
       input.onEvent,
       input.onDisconnect
     )
@@ -78,14 +83,18 @@ export class TerminalProviderRpcConnection {
       protocolVersion: this.protocolVersion,
       requestId,
       authToken: this.authToken,
+      controllerLeaseId: this.controllerLeaseId,
       method,
-      params
+      params,
+      deadlineMs: this.requestDeadlineMs
     }
     return new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(requestId)
-        reject(providerUnavailable(`Terminal provider request timed out: ${method}`))
-      }, providerRequestTimeoutMs)
+        const error = providerUnavailable(`Terminal provider request timed out: ${method}`)
+        reject(error)
+        this.socket.destroy()
+      }, this.requestDeadlineMs + providerRequestDeadlineGraceMs)
       this.pending.set(requestId, {
         resolve: (value) => resolve(value as T),
         reject,
@@ -98,6 +107,17 @@ export class TerminalProviderRpcConnection {
   close(): void {
     this.socket.end()
     this.socket.destroy()
+  }
+
+  async claimController(controllerId: string, processId: number): Promise<void> {
+    const claim = await this.request<{ readonly controllerLeaseId: string }>('claimController', {
+      controllerId,
+      processId
+    })
+    if (!claim.controllerLeaseId) {
+      throw providerUnavailable('Terminal provider returned an invalid controller lease.')
+    }
+    this.controllerLeaseId = claim.controllerLeaseId
   }
 
   private handleMessage(value: unknown): void {
@@ -134,4 +154,9 @@ function isProviderMessage(value: unknown): value is TerminalProviderMessage {
 
 function providerUnavailable(message: string) {
   return createExpectedAppError('TERMINAL_PROVIDER_UNAVAILABLE', message)
+}
+
+function resolveRequestDeadline(value: number | undefined): number {
+  if (value === undefined) return terminalProviderDefaultRequestDeadlineMs
+  return Math.max(1, Math.min(terminalProviderDefaultRequestDeadlineMs, Math.floor(value)))
 }

--- a/src/contexts/run/infrastructure/provider/TerminalProviderServer.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderServer.ts
@@ -21,22 +21,13 @@ import { HeadlessTerminalModelAdapter } from '../terminal-model/HeadlessTerminal
 import { NodePtyTerminalProcessAdapter } from '../pty/NodePtyTerminalProcessAdapter'
 import {
   type TerminalProviderEvent,
-  TerminalProviderFrameDecoder,
   terminalProviderMaxOutputChunkBytes,
   terminalProviderProtocolVersion
 } from './TerminalProviderProtocol'
+import { createExpectedAppError } from '../../../../shared-kernel/application/errors/AppError'
 import {
-  createExpectedAppError,
-  createUnexpectedAppError,
-  isAppError,
-  serializeAppError
-} from '../../../../shared-kernel/application/errors/AppError'
-import {
-  authenticateTerminalProviderRequest,
-  authorizeTerminalProviderController,
   createProviderSessionSnapshot,
   getErrorMessage,
-  isTerminalProviderRequest,
   sendTerminalProviderMessage,
   splitUtf8
 } from './TerminalProviderServerSupport'
@@ -45,14 +36,18 @@ import { TerminalProviderSessionPersistence } from './TerminalProviderSessionPer
 import { TerminalProviderControllerLifecycle } from './TerminalProviderControllerLifecycle'
 import { TerminalProviderShutdownCoordinator } from './TerminalProviderShutdownCoordinator'
 import {
+  attachTerminalProviderSocket,
+  withTerminalProviderOperationDeadline
+} from './TerminalProviderSocketHandler'
+import {
   countLiveProviderSessions,
   hasLiveProviderSessions,
-  hasUnsafeLiveProviderSessions,
   type ProviderTerminalSession,
   type TerminalProviderRequestParams
 } from './TerminalProviderServerTypes'
 
 const maxRetainedLiveSessions = 32
+const providerCloseCheckpointDeadlineMs = 750
 
 export interface TerminalProviderServerOptions {
   readonly endpoint: string
@@ -75,6 +70,7 @@ export class TerminalProviderServer {
   private readonly shutdownCoordinator: TerminalProviderShutdownCoordinator
   private readonly controllerLifecycle: TerminalProviderControllerLifecycle
   private readonly sessions = new Map<string, ProviderTerminalSession>()
+  private readonly modelIdentities = new Map<string, TerminalRunScope>()
   private readonly recoveryIssues: TerminalRecoveryLoadIssue[] = []
   private readonly sockets = new Set<Socket>()
   private server: Server | null = null
@@ -95,6 +91,10 @@ export class TerminalProviderServer {
           this.recordPersistenceFailure(error, session)
           return
         }
+        const current = this.sessions.get(session.snapshot.sessionId)
+        if (current && isSameTerminalRun(current.snapshot, session.snapshot)) {
+          current.quarantined = true
+        }
         this.log('shutdown-session-failed', {
           message: getErrorMessage(error),
           sessionId: session.snapshot.sessionId
@@ -109,7 +109,6 @@ export class TerminalProviderServer {
         )
       },
       hasLiveSessions: () => hasLiveProviderSessions(this.sessions.values()),
-      hasUnsafeLiveSessions: () => hasUnsafeLiveProviderSessions(this.sessions.values()),
       isProcessAlive: isControllerProcessAlive,
       log: (message, details) => this.log(message, details),
       onClaim: () => this.prepareControllerClaim(),
@@ -142,11 +141,19 @@ export class TerminalProviderServer {
     this.isClosing = true
     if (this.exitTimer) clearTimeout(this.exitTimer)
     this.exitTimer = null
-    for (const session of this.sessions.values()) {
-      await session.persistence
-        .checkpoint(true)
-        .catch((error) => this.log('checkpoint-failed', { message: getErrorMessage(error) }))
-    }
+    await Promise.allSettled(
+      [...this.sessions.values()].map((session) =>
+        withTerminalProviderOperationDeadline(
+          session.persistence.checkpoint(true),
+          providerCloseCheckpointDeadlineMs
+        ).catch((error) =>
+          this.log('checkpoint-failed', {
+            message: getErrorMessage(error),
+            sessionId: session.snapshot.sessionId
+          })
+        )
+      )
+    )
     for (const socket of this.sockets) socket.destroy()
     await new Promise<void>((resolve) => {
       if (!this.server) return resolve()
@@ -158,66 +165,19 @@ export class TerminalProviderServer {
   }
 
   private acceptSocket(socket: Socket): void {
-    const decoder = new TerminalProviderFrameDecoder()
-    let detachedCleanly = false
-    let requestTail = Promise.resolve()
     this.sockets.add(socket)
-    socket.on('data', (chunk) => {
-      try {
-        for (const message of decoder.push(chunk)) {
-          requestTail = requestTail
-            .then(async () => {
-              detachedCleanly ||= await this.handleRequest(socket, message)
-            })
-            .catch((error) => {
-              this.log('protocol-error', { message: getErrorMessage(error) })
-              socket.destroy()
-            })
-        }
-      } catch (error) {
-        this.log('protocol-error', { message: getErrorMessage(error) })
-        socket.destroy()
-      }
+    attachTerminalProviderSocket({
+      authToken: this.options.authToken,
+      dispatch: (method, params, activeSocket) => this.dispatch(method, params, activeSocket),
+      getControllerState: () => this.controllerLifecycle.state,
+      log: (message, details) => this.log(message, details),
+      onClose: (detachedCleanly) => {
+        this.sockets.delete(socket)
+        if (this.isClosing || detachedCleanly) return
+        this.controllerLifecycle.handleSocketClose(socket)
+      },
+      socket
     })
-    socket.on('close', () => {
-      this.sockets.delete(socket)
-      if (this.isClosing || detachedCleanly) return
-      const pendingRequests = requestTail
-      void pendingRequests.finally(() => this.controllerLifecycle.handleSocketClose(socket))
-    })
-    socket.on('error', (error) => this.log('socket-error', { message: error.message }))
-  }
-
-  private async handleRequest(socket: Socket, value: unknown): Promise<boolean> {
-    if (!isTerminalProviderRequest(value)) {
-      socket.destroy()
-      return false
-    }
-    const request = value
-    try {
-      authenticateTerminalProviderRequest(request, this.options.authToken)
-      authorizeTerminalProviderController(socket, request.method, this.controllerLifecycle.state)
-      const result = await this.dispatch(request.method, request.params, socket)
-      sendTerminalProviderMessage(socket, {
-        type: 'response',
-        requestId: request.requestId,
-        ok: true,
-        result
-      })
-      if (request.method === 'detachApplication' || request.method === 'awaitApplicationDetach') {
-        setTimeout(() => socket.end(), 0)
-        return true
-      }
-    } catch (error) {
-      const appError = isAppError(error) ? error : createUnexpectedAppError(getErrorMessage(error))
-      sendTerminalProviderMessage(socket, {
-        type: 'response',
-        requestId: request.requestId,
-        ok: false,
-        error: serializeAppError(appError)
-      })
-    }
-    return false
   }
 
   private async dispatch(method: string, params: unknown, socket: Socket): Promise<unknown> {
@@ -234,10 +194,13 @@ export class TerminalProviderServer {
         return this.controllerLifecycle.claim(socket, input.controllerId, input.processId)
       case 'listSessions':
         return {
-          sessions: [...this.sessions.values()].map(({ snapshot }) => snapshot),
+          sessions: [...this.sessions.values()]
+            .filter(({ quarantined, snapshot }) => !quarantined && snapshot.status !== 'idle')
+            .map(({ snapshot }) => snapshot),
           issues: this.recoveryIssues,
           managedServiceEndpoints: [...this.sessions.values()].flatMap((session) =>
             session.managedServiceEndpoint &&
+            !session.quarantined &&
             session.snapshot.status === 'running' &&
             session.snapshot.processId !== null
               ? [
@@ -250,7 +213,13 @@ export class TerminalProviderServer {
               : []
           )
         }
-      case 'createModel':
+      case 'createModel': {
+        const identity = input.command.identity
+        const existingIdentity = this.modelIdentities.get(identity.sessionId)
+        if (existingIdentity) {
+          if (isSameTerminalRun(existingIdentity, identity)) return null
+          throw createExpectedAppError('RUN_SCOPE_STALE', 'Terminal model identity is stale.')
+        }
         this.models.create({
           ...input.command,
           onQueryResponse: (response) => {
@@ -277,7 +246,9 @@ export class TerminalProviderServer {
             })
           }
         })
+        this.modelIdentities.set(identity.sessionId, identity)
         return null
+      }
       case 'startProcess':
         return this.startProcess(input.command)
       case 'launchForegroundJob':
@@ -333,6 +304,7 @@ export class TerminalProviderServer {
         return null
       case 'disposeModels':
         this.models.disposeAll()
+        this.modelIdentities.clear()
         return null
       case 'getDiagnostics':
         return this.models.getDiagnostics()
@@ -368,6 +340,30 @@ export class TerminalProviderServer {
   private async startProcess(
     command: Omit<StartTerminalProcessCommand, 'onOutput' | 'onExit'>
   ): Promise<{ readonly processId: number }> {
+    const existing = this.sessions.get(command.scope.sessionId)
+    if (existing) {
+      if (existing.quarantined) {
+        throw createExpectedAppError(
+          'TERMINAL_PROVIDER_CONTROLLER_BUSY',
+          'Terminal session is quarantined after an incomplete controller release.'
+        )
+      }
+      if (
+        isSameTerminalRun(existing.snapshot, command.scope) &&
+        existing.snapshot.status === 'running' &&
+        existing.snapshot.processId !== null
+      ) {
+        return { processId: existing.snapshot.processId }
+      }
+      if (isSameTerminalRun(existing.snapshot, command.scope) && existing.starting) {
+        throw createExpectedAppError(
+          'TERMINAL_PROVIDER_CONTROLLER_BUSY',
+          'Terminal session is still starting.',
+          { retryAfterMs: 50 }
+        )
+      }
+      throw createExpectedAppError('RUN_SCOPE_STALE', 'Terminal session identity is stale.')
+    }
     if (countLiveProviderSessions(this.sessions.values()) >= maxRetainedLiveSessions) {
       throw createExpectedAppError(
         'TERMINAL_RECOVERY_STORAGE_LIMIT',
@@ -378,11 +374,17 @@ export class TerminalProviderServer {
     this.sessions.set(command.scope.sessionId, session)
     try {
       await session.persistence.checkpoint(true)
+      if (session.retired) throw providerSessionRetiredDuringStart()
       const handle = await this.processes.start({
         ...command,
         onOutput: (event) => this.acceptProcessOutput(session, event.data),
         onExit: (event) => void this.handleProcessExit(session, event.exitCode)
       })
+      session.starting = false
+      if (session.retired || this.sessions.get(command.scope.sessionId) !== session) {
+        await this.processes.stop(command.scope.sessionId).catch(() => undefined)
+        throw providerSessionRetiredDuringStart()
+      }
       if (session.snapshot.status === 'idle') {
         session.snapshot = {
           ...session.snapshot,
@@ -393,6 +395,7 @@ export class TerminalProviderServer {
       }
       return handle
     } catch (error) {
+      session.starting = false
       await this.retireSession(command.scope)
       throw error
     }
@@ -491,10 +494,15 @@ export class TerminalProviderServer {
 
   private async retireSession(identity: TerminalRunScope): Promise<void> {
     const session = this.sessions.get(identity.sessionId)
-    if (!session || !isSameTerminalRun(session.snapshot, identity)) return
-    session.retired = true
-    await session.persistence.retire()
-    this.models.retire(identity)
+    const exactSession = session && isSameTerminalRun(session.snapshot, identity) ? session : null
+    if (exactSession) exactSession.retired = true
+    const modelIdentity = this.modelIdentities.get(identity.sessionId)
+    if (modelIdentity && isSameTerminalRun(modelIdentity, identity)) {
+      this.models.retire(identity)
+      this.modelIdentities.delete(identity.sessionId)
+    }
+    if (!exactSession) return
+    await exactSession.persistence.retire()
     this.sessions.delete(identity.sessionId)
     await this.store.delete(identity)
   }
@@ -522,6 +530,7 @@ export class TerminalProviderServer {
         onQueryResponse: () => undefined,
         onFlowControlChange: () => undefined
       })
+      this.modelIdentities.set(exactCheckpoint.identity.sessionId, exactCheckpoint.identity)
       for (const output of bundle.output) {
         this.models.acceptOutput(exactCheckpoint.identity, output.data)
       }
@@ -553,7 +562,9 @@ export class TerminalProviderServer {
     const sessionState: Omit<ProviderTerminalSession, 'persistence'> = {
       snapshot,
       managedServiceEndpoint: undefined,
-      retired: false
+      quarantined: false,
+      retired: false,
+      starting: snapshot.status === 'idle'
     }
     const persistence = new TerminalProviderSessionPersistence({
       batchWindowMs: this.options.outputPersistenceBatchWindowMs,
@@ -593,6 +604,12 @@ export class TerminalProviderServer {
     if (!session) {
       throw createExpectedAppError('TERMINAL_SESSION_NOT_FOUND', 'Terminal session was not found.')
     }
+    if (session.quarantined) {
+      throw createExpectedAppError(
+        'TERMINAL_PROVIDER_UNAVAILABLE',
+        'Terminal session is quarantined after an incomplete controller release.'
+      )
+    }
     return session
   }
 
@@ -628,4 +645,11 @@ function isControllerProcessAlive(processId: number): boolean {
   } catch {
     return false
   }
+}
+
+function providerSessionRetiredDuringStart() {
+  return createExpectedAppError(
+    'TERMINAL_PROVIDER_UNAVAILABLE',
+    'Terminal session was retired while its process was starting.'
+  )
 }

--- a/src/contexts/run/infrastructure/provider/TerminalProviderServerSupport.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderServerSupport.ts
@@ -17,7 +17,10 @@ export function authenticateTerminalProviderRequest(
   request: TerminalProviderRequest,
   expectedAuthToken: string
 ): void {
-  if (request.protocolVersion !== terminalProviderProtocolVersion) {
+  if (
+    request.protocolVersion < terminalProviderProtocolVersion - 1 ||
+    request.protocolVersion > terminalProviderProtocolVersion
+  ) {
     throw createExpectedAppError(
       'TERMINAL_PROVIDER_PROTOCOL_UNSUPPORTED',
       'Terminal provider protocol version is unsupported.'
@@ -33,14 +36,22 @@ export function authenticateTerminalProviderRequest(
 
 export function authorizeTerminalProviderController(
   socket: Socket,
-  method: string,
+  request: TerminalProviderRequest,
   state: ProviderControllerState
 ): void {
+  const method = request.method
   if (method === 'health' || method === 'claimController') return
-  if (state.kind === 'active' && state.socket === socket) return
+  if (
+    state.kind === 'active' &&
+    state.socket === socket &&
+    hasCurrentControllerLease(request, state.controllerLeaseId)
+  ) {
+    return
+  }
   if (
     state.kind === 'releasing' &&
     state.socket === socket &&
+    hasCurrentControllerLease(request, state.controllerLeaseId) &&
     (method === 'beginApplicationDetach' ||
       method === 'awaitApplicationDetach' ||
       method === 'detachApplication')
@@ -104,9 +115,23 @@ export function isTerminalProviderRequest(value: unknown): value is TerminalProv
     typeof value.requestId === 'string' &&
     'authToken' in value &&
     typeof value.authToken === 'string' &&
+    (!('controllerLeaseId' in value) || typeof value.controllerLeaseId === 'string') &&
     'method' in value &&
-    typeof value.method === 'string'
+    typeof value.method === 'string' &&
+    (!('deadlineMs' in value) ||
+      (typeof value.deadlineMs === 'number' &&
+        Number.isFinite(value.deadlineMs) &&
+        value.deadlineMs > 0))
   )
+}
+
+function hasCurrentControllerLease(
+  request: TerminalProviderRequest,
+  controllerLeaseId: string
+): boolean {
+  return request.protocolVersion < terminalProviderProtocolVersion
+    ? request.controllerLeaseId === undefined || request.controllerLeaseId === controllerLeaseId
+    : request.controllerLeaseId === controllerLeaseId
 }
 
 export function getErrorMessage(error: unknown): string {

--- a/src/contexts/run/infrastructure/provider/TerminalProviderServerTypes.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderServerTypes.ts
@@ -11,13 +11,14 @@ import type { ActualServiceEndpoint } from '../../domain/value-objects/ActualSer
 import type { TerminalRunScope } from '../../domain/value-objects/TerminalRunScope'
 import type { TerminalProviderSessionPersistence } from './TerminalProviderSessionPersistence'
 import type { TerminalProviderApplicationDetachResult } from './TerminalProviderProtocol'
-import { shouldTerminateProviderSession } from './TerminalProviderShutdownCoordinator'
 
 export interface ProviderTerminalSession {
   snapshot: TerminalSessionSnapshot
   persistence: TerminalProviderSessionPersistence
   managedServiceEndpoint: ActualServiceEndpoint | undefined
+  quarantined: boolean
   retired: boolean
+  starting: boolean
 }
 
 export type ProviderControllerReleaseReason = 'application-detach' | 'unexpected-disconnect'
@@ -63,17 +64,10 @@ export interface TerminalProviderRequestParams {
 }
 
 export function countLiveProviderSessions(sessions: Iterable<ProviderTerminalSession>): number {
-  return [...sessions].filter(({ snapshot }) => snapshot.status === 'running').length
+  return [...sessions].filter(({ snapshot, starting }) => snapshot.status === 'running' || starting)
+    .length
 }
 
 export function hasLiveProviderSessions(sessions: Iterable<ProviderTerminalSession>): boolean {
-  return [...sessions].some(({ snapshot }) => snapshot.status === 'running')
-}
-
-export function hasUnsafeLiveProviderSessions(
-  sessions: Iterable<ProviderTerminalSession>
-): boolean {
-  return [...sessions].some(
-    ({ snapshot }) => snapshot.status === 'running' && shouldTerminateProviderSession(snapshot)
-  )
+  return [...sessions].some(({ snapshot, starting }) => snapshot.status === 'running' || starting)
 }

--- a/src/contexts/run/infrastructure/provider/TerminalProviderSessionPersistence.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderSessionPersistence.ts
@@ -66,7 +66,6 @@ export class TerminalProviderSessionPersistence {
   async retire(): Promise<void> {
     this.clearTimers()
     this.pendingOutputs = []
-    await this.tail.catch(() => undefined)
   }
 
   private scheduleOutputFlush(): void {
@@ -111,6 +110,7 @@ export class TerminalProviderSessionPersistence {
     model: TerminalModelCheckpoint,
     truncateOutputLog: boolean
   ): Promise<void> {
+    if (this.options.isRetired()) return Promise.resolve()
     const record: TerminalRecoveryRecord = {
       schemaVersion: 2,
       providerInstanceId: this.options.instanceId,

--- a/src/contexts/run/infrastructure/provider/TerminalProviderShutdownCoordinator.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderShutdownCoordinator.ts
@@ -5,11 +5,16 @@ import {
   type TerminalRunScope
 } from '../../domain/value-objects/TerminalRunScope'
 import type { TerminalProviderApplicationDetachResult } from './TerminalProviderProtocol'
+import { createExpectedAppError } from '../../../../shared-kernel/application/errors/AppError'
 
 const defaultShutdownConcurrency = 8
+const defaultCheckpointDeadlineMs = 750
+const defaultRetireDeadlineMs = 750
+const defaultStopDeadlineMs = 2_500
 
 export interface TerminalProviderShutdownSession {
   readonly snapshot: TerminalSessionSnapshot
+  readonly starting?: boolean
   readonly persistence: {
     checkpoint(truncateOutputLog: boolean): Promise<void>
   }
@@ -17,6 +22,10 @@ export interface TerminalProviderShutdownSession {
 
 interface TerminalProviderShutdownCoordinatorOptions {
   readonly concurrency?: number
+  readonly checkpointDeadlineMs?: number
+  readonly operationDeadlineMs?: number
+  readonly retireDeadlineMs?: number
+  readonly stopDeadlineMs?: number
   readonly processes: Pick<TerminalProcessPort, 'stop'>
   readonly retireSession: (identity: TerminalRunScope) => Promise<void>
   readonly onFailure?: (
@@ -40,9 +49,24 @@ interface CapturedSession {
 
 export class TerminalProviderShutdownCoordinator {
   private readonly concurrency: number
+  private readonly checkpointDeadlineMs: number
+  private readonly retireDeadlineMs: number
+  private readonly stopDeadlineMs: number
 
   constructor(private readonly options: TerminalProviderShutdownCoordinatorOptions) {
     this.concurrency = Math.max(1, Math.floor(options.concurrency ?? defaultShutdownConcurrency))
+    this.checkpointDeadlineMs = resolveDeadline(
+      options.operationDeadlineMs ?? options.checkpointDeadlineMs,
+      defaultCheckpointDeadlineMs
+    )
+    this.retireDeadlineMs = resolveDeadline(
+      options.operationDeadlineMs ?? options.retireDeadlineMs,
+      defaultRetireDeadlineMs
+    )
+    this.stopDeadlineMs = resolveDeadline(
+      options.operationDeadlineMs ?? options.stopDeadlineMs,
+      defaultStopDeadlineMs
+    )
   }
 
   async release(
@@ -60,19 +84,29 @@ export class TerminalProviderShutdownCoordinator {
     const terminate = async (candidate: CapturedSession): Promise<void> => {
       try {
         if (candidate.isRunning) {
-          await this.options.processes.stop(candidate.identity.sessionId)
+          await withOperationDeadline(
+            this.options.processes.stop(candidate.identity.sessionId),
+            this.stopDeadlineMs,
+            'stop terminal process'
+          )
           stoppedSessionCount += 1
         }
-        await this.options.retireSession(candidate.identity)
+        await withOperationDeadline(
+          this.options.retireSession(candidate.identity),
+          this.retireDeadlineMs,
+          'retire terminal session'
+        )
         retiredSessionCount += 1
       } catch (error) {
         failedSessions.add(candidate.identity.sessionId)
         this.options.onFailure?.(error, candidate.session, 'stop-or-retire')
-        await candidate.session.persistence
-          .checkpoint(true)
-          .catch((checkpointError) =>
-            this.options.onFailure?.(checkpointError, candidate.session, 'checkpoint')
-          )
+        await withOperationDeadline(
+          candidate.session.persistence.checkpoint(true),
+          this.checkpointDeadlineMs,
+          'checkpoint failed terminal session'
+        ).catch((checkpointError) =>
+          this.options.onFailure?.(checkpointError, candidate.session, 'checkpoint')
+        )
       }
     }
 
@@ -82,7 +116,11 @@ export class TerminalProviderShutdownCoordinator {
       async (candidate) => {
         if (!candidate.shouldTerminate) {
           try {
-            await candidate.session.persistence.checkpoint(true)
+            await withOperationDeadline(
+              candidate.session.persistence.checkpoint(true),
+              this.checkpointDeadlineMs,
+              'checkpoint terminal session'
+            )
             retainedSessionCount += 1
           } catch (error) {
             failedSessions.add(candidate.identity.sessionId)
@@ -108,17 +146,43 @@ export class TerminalProviderShutdownCoordinator {
   }
 }
 
+function resolveDeadline(value: number | undefined, fallback: number): number {
+  return Math.max(1, Math.floor(value ?? fallback))
+}
+
+function withOperationDeadline<T>(
+  operation: Promise<T>,
+  deadlineMs: number,
+  operationName: string
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(
+        createExpectedAppError(
+          'COMMAND_TIMED_OUT',
+          `Terminal provider could not ${operationName} before its deadline.`
+        )
+      )
+    }, deadlineMs)
+    timeout.unref()
+  })
+  return Promise.race([operation, deadline]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+}
+
 function captureSession(session: TerminalProviderShutdownSession): CapturedSession {
   const snapshot = session.snapshot
   return {
     identity: snapshot,
-    isRunning: snapshot.status === 'running',
+    isRunning: snapshot.status === 'running' || session.starting === true,
     session,
     shouldTerminate: shouldTerminateProviderSession(snapshot)
   }
 }
 
-export function shouldTerminateProviderSession(snapshot: TerminalSessionSnapshot): boolean {
+function shouldTerminateProviderSession(snapshot: TerminalSessionSnapshot): boolean {
   return (
     snapshot.kind === 'workflow' ||
     resolveTerminalOwnerRef(snapshot).kind === 'agent' ||

--- a/src/contexts/run/infrastructure/provider/TerminalProviderSocketHandler.ts
+++ b/src/contexts/run/infrastructure/provider/TerminalProviderSocketHandler.ts
@@ -1,0 +1,168 @@
+import type { Socket } from 'node:net'
+
+import {
+  createExpectedAppError,
+  createUnexpectedAppError,
+  isAppError,
+  serializeAppError
+} from '../../../../shared-kernel/application/errors/AppError'
+import {
+  TerminalProviderFrameDecoder,
+  type TerminalProviderRequest,
+  terminalProviderDefaultRequestDeadlineMs
+} from './TerminalProviderProtocol'
+import { TerminalProviderRequestScheduler } from './TerminalProviderRequestScheduler'
+import {
+  authenticateTerminalProviderRequest,
+  authorizeTerminalProviderController,
+  getErrorMessage,
+  isTerminalProviderRequest,
+  sendTerminalProviderMessage
+} from './TerminalProviderServerSupport'
+import type { ProviderControllerState } from './TerminalProviderServerTypes'
+
+interface TerminalProviderSocketHandlerOptions {
+  readonly authToken: string
+  readonly dispatch: (method: string, params: unknown, socket: Socket) => Promise<unknown>
+  readonly getControllerState: () => ProviderControllerState
+  readonly log: (message: string, details?: Readonly<Record<string, unknown>>) => void
+  readonly onClose: (detachedCleanly: boolean) => void
+  readonly socket: Socket
+}
+
+export function attachTerminalProviderSocket(options: TerminalProviderSocketHandlerOptions): void {
+  const decoder = new TerminalProviderFrameDecoder()
+  const scheduler = new TerminalProviderRequestScheduler()
+  const activeRequests = new Map<string, AbortController>()
+  let detachedCleanly = false
+
+  options.socket.on('data', (chunk) => {
+    try {
+      for (const message of decoder.push(chunk)) {
+        if (!isTerminalProviderRequest(message)) {
+          options.socket.destroy()
+          return
+        }
+        void scheduler
+          .schedule(message, async () => {
+            detachedCleanly ||= await handleRequest(options, message, activeRequests)
+          })
+          .catch((error) => {
+            options.log('protocol-error', { message: getErrorMessage(error) })
+            options.socket.destroy()
+          })
+      }
+    } catch (error) {
+      options.log('protocol-error', { message: getErrorMessage(error) })
+      options.socket.destroy()
+    }
+  })
+  options.socket.on('close', () => {
+    for (const controller of activeRequests.values()) controller.abort()
+    activeRequests.clear()
+    options.onClose(detachedCleanly)
+  })
+  options.socket.on('error', (error) => options.log('socket-error', { message: error.message }))
+}
+
+export function withTerminalProviderOperationDeadline<T>(
+  operation: Promise<T>,
+  deadlineMs: number
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(providerRequestDeadlineExceeded()), deadlineMs)
+    timeout.unref()
+  })
+  return Promise.race([operation, deadline]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+}
+
+async function handleRequest(
+  options: TerminalProviderSocketHandlerOptions,
+  request: TerminalProviderRequest,
+  activeRequests: Map<string, AbortController>
+): Promise<boolean> {
+  const startedAt = performance.now()
+  const controller = new AbortController()
+  activeRequests.set(request.requestId, controller)
+  const deadlineMs = Math.min(
+    terminalProviderDefaultRequestDeadlineMs,
+    request.deadlineMs ?? terminalProviderDefaultRequestDeadlineMs
+  )
+  const deadline = setTimeout(() => controller.abort(), deadlineMs)
+  deadline.unref()
+  try {
+    authenticateTerminalProviderRequest(request, options.authToken)
+    authorizeTerminalProviderController(options.socket, request, options.getControllerState())
+    const result = await raceRequestDeadline(
+      options.dispatch(request.method, request.params, options.socket),
+      controller.signal
+    )
+    sendTerminalProviderMessage(options.socket, {
+      type: 'response',
+      requestId: request.requestId,
+      ok: true,
+      result
+    })
+    logSlowRequest(options, request, startedAt)
+    if (request.method === 'detachApplication' || request.method === 'awaitApplicationDetach') {
+      setTimeout(() => options.socket.end(), 0)
+      return true
+    }
+  } catch (error) {
+    const appError = isAppError(error) ? error : createUnexpectedAppError(getErrorMessage(error))
+    options.log('request-failed', {
+      code: appError.code,
+      durationMs: Math.round(performance.now() - startedAt),
+      method: request.method,
+      requestId: request.requestId
+    })
+    sendTerminalProviderMessage(options.socket, {
+      type: 'response',
+      requestId: request.requestId,
+      ok: false,
+      error: serializeAppError(appError)
+    })
+  } finally {
+    clearTimeout(deadline)
+    activeRequests.delete(request.requestId)
+  }
+  return false
+}
+
+function raceRequestDeadline<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(providerRequestDeadlineExceeded())
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(providerRequestDeadlineExceeded())
+    signal.addEventListener('abort', abort, { once: true })
+    void operation.then(
+      (value) => {
+        signal.removeEventListener('abort', abort)
+        resolve(value)
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', abort)
+        reject(error)
+      }
+    )
+  })
+}
+
+function logSlowRequest(
+  options: TerminalProviderSocketHandlerOptions,
+  request: TerminalProviderRequest,
+  startedAt: number
+): void {
+  const durationMs = Math.round(performance.now() - startedAt)
+  if (durationMs < 500) return
+  options.log('request-slow', { durationMs, method: request.method, requestId: request.requestId })
+}
+
+function providerRequestDeadlineExceeded() {
+  return createExpectedAppError(
+    'COMMAND_TIMED_OUT',
+    'Terminal provider request exceeded its deadline.'
+  )
+}

--- a/src/platform/electron-main/main.ts
+++ b/src/platform/electron-main/main.ts
@@ -127,6 +127,7 @@ if (acquiresSingleInstanceLock) {
 }
 
 const appStateDirectoryPath = getAppStateDirectoryPath()
+consoleLogger.configureFile(join(appStateDirectoryPath, 'logs', 'main.log'))
 const projectRepository = new FileSystemProjectRepository(appStateDirectoryPath)
 let projectRegistryRepository: FileSystemProjectRegistryRepository | null = null
 const graphRepository = new FileSystemBlockGraphRepository(appStateDirectoryPath)

--- a/src/platform/electron-main/terminal-runtime-provider.ts
+++ b/src/platform/electron-main/terminal-runtime-provider.ts
@@ -1,8 +1,12 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { appendFile, readFile, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 import { TerminalProviderServer } from '../../contexts/run/infrastructure/provider/TerminalProviderServer'
 import { terminalProviderProtocolVersion } from '../../contexts/run/infrastructure/provider/TerminalProviderProtocol'
+import { rotateProviderLog } from '../../contexts/run/infrastructure/provider/PersistentTerminalProviderClientSupport'
+
+const maxProviderLogBytes = 5 * 1024 * 1024
+let diagnosticTail: Promise<void> = Promise.resolve()
 
 interface ProviderMetadata {
   readonly schemaVersion: 1
@@ -33,8 +37,15 @@ async function startProvider(): Promise<void> {
   })
   await server.start()
 
+  let isClosing = false
   const close = () => {
-    void server.close().finally(() => process.exit(0))
+    if (isClosing) return
+    isClosing = true
+    const forceExit = setTimeout(() => process.exit(1), 4_500)
+    void server.close().finally(() => {
+      clearTimeout(forceExit)
+      process.exit(0)
+    })
   }
   process.once('SIGTERM', close)
   process.once('SIGINT', close)
@@ -74,9 +85,21 @@ async function writeProviderDiagnostic(
 ): Promise<void> {
   const metadataPath = process.argv[process.argv.indexOf('--metadata') + 1]
   if (!metadataPath) return
-  const line = JSON.stringify({ timestamp: new Date().toISOString(), event, ...details })
-  await appendFile(join(dirname(metadataPath), 'provider.log'), `${line}\n`, {
-    encoding: 'utf8',
-    mode: 0o600
-  }).catch(() => undefined)
+  const logPath = join(dirname(metadataPath), 'provider.log')
+  diagnosticTail = diagnosticTail
+    .catch(() => undefined)
+    .then(async () => {
+      if ((await fileSize(logPath)) >= maxProviderLogBytes) rotateProviderLog(logPath)
+      const line = JSON.stringify({ timestamp: new Date().toISOString(), event, ...details })
+      await appendFile(logPath, `${line}\n`, { encoding: 'utf8', mode: 0o600 })
+    })
+  await diagnosticTail.catch(() => undefined)
+}
+
+async function fileSize(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size
+  } catch {
+    return 0
+  }
 }

--- a/src/platform/logging/ConsoleLogSink.ts
+++ b/src/platform/logging/ConsoleLogSink.ts
@@ -1,6 +1,23 @@
+import { appendFileSync, existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs'
+import { dirname } from 'node:path'
+
 import type { LogEvent, LogLevel, Logger } from './Logger'
 
+const maxLogBytes = 5 * 1024 * 1024
+
 class ConsoleLogger implements Logger {
+  private filePath: string | null = null
+
+  configureFile(path: string): void {
+    try {
+      mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
+      rotateLog(path)
+      this.filePath = path
+    } catch {
+      this.filePath = null
+    }
+  }
+
   debug(event: Omit<LogEvent, 'level' | 'timestamp'>): void {
     this.write('debug', event)
   }
@@ -24,6 +41,16 @@ class ConsoleLogger implements Logger {
       timestamp: new Date().toISOString()
     }
     const line = JSON.stringify(record)
+    if (this.filePath) {
+      try {
+        if (existsSync(this.filePath) && statSync(this.filePath).size >= maxLogBytes) {
+          rotateLog(this.filePath)
+        }
+        appendFileSync(this.filePath, `${line}\n`, { encoding: 'utf8', mode: 0o600 })
+      } catch {
+        // Console diagnostics remain available when the local file cannot be written.
+      }
+    }
 
     if (level === 'error') {
       console.error(line)
@@ -40,3 +67,13 @@ class ConsoleLogger implements Logger {
 }
 
 export const consoleLogger = new ConsoleLogger()
+
+function rotateLog(path: string): void {
+  for (let index = 3; index >= 1; index -= 1) {
+    const source = index === 1 ? path : `${path}.${index - 1}`
+    const target = `${path}.${index}`
+    if (!existsSync(source)) continue
+    rmSync(target, { force: true })
+    renameSync(source, target)
+  }
+}

--- a/tests/integration/contexts/run/run.terminal-provider-client-lifecycle.spec.ts
+++ b/tests/integration/contexts/run/run.terminal-provider-client-lifecycle.spec.ts
@@ -155,14 +155,56 @@ describe('persistent terminal provider client lifecycle', () => {
   it('publishes runtime unavailability when an established Provider disconnects', async () => {
     const runtimeUnavailable = vi.fn()
     const client = createClient(rootDirectory, undefined, runtimeUnavailable)
+    const onExit = vi.fn()
 
     await client.initialize()
+    client.bindRecoveredSession(outputIdentity('block'), {
+      onExit,
+      onOutput: vi.fn()
+    })
     provider.disconnectClients()
 
     await vi.waitFor(() =>
       expect(runtimeUnavailable).toHaveBeenCalledWith(
         expect.objectContaining({ code: 'TERMINAL_PROVIDER_UNAVAILABLE' })
       )
+    )
+    expect(onExit).not.toHaveBeenCalled()
+    await client.detachApplication()
+  })
+
+  it('invalidates runtime readiness when an unresponsive Provider exceeds the client deadline', async () => {
+    const runtimeUnavailable = vi.fn()
+    const client = createClient(rootDirectory, undefined, runtimeUnavailable, undefined, 25)
+    await client.initialize()
+    provider.pauseMethodResponses('flushModel')
+
+    await expect(client.flush(outputIdentity('block'))).rejects.toMatchObject({
+      code: 'TERMINAL_PROVIDER_UNAVAILABLE'
+    })
+    await vi.waitFor(() =>
+      expect(runtimeUnavailable).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'TERMINAL_PROVIDER_UNAVAILABLE' })
+      )
+    )
+    await client.detachApplication()
+  })
+
+  it('invalidates cached readiness when the Provider reports a server-side deadline', async () => {
+    const runtimeUnavailable = vi.fn()
+    const client = createClient(rootDirectory, undefined, runtimeUnavailable)
+    await client.initialize()
+    provider.failMethod('flushModel', {
+      code: 'COMMAND_TIMED_OUT',
+      isExpected: true,
+      message: 'Provider request exceeded its deadline.'
+    })
+
+    await expect(client.flush(outputIdentity('block'))).rejects.toMatchObject({
+      code: 'COMMAND_TIMED_OUT'
+    })
+    expect(runtimeUnavailable).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'COMMAND_TIMED_OUT' })
     )
     await client.detachApplication()
   })
@@ -362,14 +404,16 @@ function createClient(
   rootDirectory: string,
   onBackgroundError?: (error: unknown) => void,
   onRuntimeUnavailable?: (error: unknown) => void,
-  onOutput?: PersistentTerminalProviderClientOptions['onOutput']
+  onOutput?: PersistentTerminalProviderClientOptions['onOutput'],
+  requestDeadlineMs?: number
 ) {
   return new PersistentTerminalProviderClient({
     stateDirectory: rootDirectory,
     providerEntryPath: join(rootDirectory, 'unused-provider-entry.js'),
     onBackgroundError,
     onRuntimeUnavailable,
-    onOutput
+    onOutput,
+    requestDeadlineMs
   })
 }
 
@@ -423,6 +467,8 @@ class ControllableProvider {
   private server: Server | null = null
   private healthResponses: Deferred | null = null
   private applicationDetachCompletion: Deferred | null = null
+  private readonly pausedMethodResponses = new Map<string, Deferred>()
+  private readonly methodFailures = new Map<string, unknown>()
   private rejectedControllerClaims = 0
   private processLifecycleBeforeStartResponse: ReturnType<typeof outputIdentity> | null = null
 
@@ -459,6 +505,14 @@ class ControllableProvider {
 
   pauseApplicationDetachCompletion(): void {
     this.applicationDetachCompletion = createDeferred()
+  }
+
+  pauseMethodResponses(method: string): void {
+    this.pausedMethodResponses.set(method, createDeferred())
+  }
+
+  failMethod(method: string, error: unknown): void {
+    this.methodFailures.set(method, error)
   }
 
   resumeApplicationDetachCompletion(): void {
@@ -512,6 +566,20 @@ class ControllableProvider {
 
   private async respond(socket: Socket, request: TerminalProviderRequest): Promise<void> {
     this.requests.push(request)
+    await this.pausedMethodResponses.get(request.method)?.promise
+    const failure = this.methodFailures.get(request.method)
+    if (failure) {
+      this.methodFailures.delete(request.method)
+      socket.write(
+        encodeTerminalProviderFrame({
+          type: 'response',
+          requestId: request.requestId,
+          ok: false,
+          error: failure
+        })
+      )
+      return
+    }
     if (request.method === 'health') await this.healthResponses?.promise
     if (request.method === 'awaitApplicationDetach') {
       await this.applicationDetachCompletion?.promise

--- a/tests/integration/contexts/run/run.terminal-provider-server.spec.ts
+++ b/tests/integration/contexts/run/run.terminal-provider-server.spec.ts
@@ -1,6 +1,4 @@
-import { randomUUID } from 'node:crypto'
 import { mkdtemp, rm } from 'node:fs/promises'
-import { connect, type Socket } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -14,13 +12,9 @@ import type { TerminalSnapshot } from '../../../../src/contexts/run/application/
 import { FileTerminalRecoveryStore } from '../../../../src/contexts/run/infrastructure/persistence/FileTerminalRecoveryStore'
 import { TerminalProviderServer } from '../../../../src/contexts/run/infrastructure/provider/TerminalProviderServer'
 import { createProviderEndpoint } from '../../../../src/contexts/run/infrastructure/provider/PersistentTerminalProviderClientSupport'
-import {
-  encodeTerminalProviderFrame,
-  type TerminalProviderEvent,
-  TerminalProviderFrameDecoder,
-  type TerminalProviderResponse,
-  terminalProviderProtocolVersion
-} from '../../../../src/contexts/run/infrastructure/provider/TerminalProviderProtocol'
+import { HeadlessTerminalModelAdapter } from '../../../../src/contexts/run/infrastructure/terminal-model/HeadlessTerminalModelAdapter'
+import { terminalProviderProtocolVersion } from '../../../../src/contexts/run/infrastructure/provider/TerminalProviderProtocol'
+import { TerminalProviderTestClient as TestProviderClient } from '../../../support/terminalProviderTestClient'
 
 describe('terminal provider server', () => {
   let rootDirectory = ''
@@ -169,6 +163,108 @@ describe('terminal provider server', () => {
     })
 
     expect(snapshot.transcript).toContain('eager startup output')
+    client.close()
+  })
+
+  it('isolates a permanently blocked model request from control and other sessions', async () => {
+    const processes = new RecordingProcessPort()
+    const models = new HeadlessTerminalModelAdapter()
+    const flush = models.flush.bind(models)
+    vi.spyOn(models, 'flush').mockImplementation((scope) => {
+      if (scope.sessionId === 'session-blocked') return new Promise(() => undefined)
+      return flush(scope)
+    })
+    server = new TerminalProviderServer({
+      endpoint,
+      authToken: 'secret-token',
+      instanceId: 'provider-1',
+      recoveryDirectory: join(rootDirectory, 'recovery'),
+      processes,
+      models
+    })
+    await server.start()
+    const client = await TestProviderClient.connect(endpoint, 'secret-token')
+    await claimController(client)
+    const blocked = identityFor('blocked')
+    const healthy = identityFor('healthy')
+    await createModel(client, blocked)
+    await createModel(client, healthy)
+
+    const blockedFlush = client.request(
+      'flushModel',
+      { identity: blocked },
+      terminalProviderProtocolVersion,
+      25
+    )
+
+    await expect(
+      client.request('health', undefined, terminalProviderProtocolVersion, 250)
+    ).resolves.toMatchObject({ instanceId: 'provider-1' })
+    await expect(
+      client.request(
+        'attachView',
+        { identity: healthy, viewId: 'healthy-view' },
+        terminalProviderProtocolVersion,
+        250
+      )
+    ).resolves.toMatchObject({ identity: healthy })
+    await expect(blockedFlush).rejects.toMatchObject({
+      code: 'COMMAND_TIMED_OUT'
+    })
+    client.close()
+  })
+
+  it('reconciles an unknown start outcome without exposing idle recovery or spawning twice', async () => {
+    const processes = new DeferredStartProcessPort()
+    server = createServer(processes)
+    await server.start()
+    const client = await TestProviderClient.connect(endpoint, 'secret-token')
+    await claimController(client)
+    const scope = identityFor('unknown-start')
+    await createModel(client, scope)
+    await createModel(client, scope)
+
+    const firstStart = client.request(
+      'startProcess',
+      {
+        command: {
+          scope,
+          workingDirectory: '/work/app',
+          columns: 80,
+          rows: 24,
+          sessionKind: 'interactive'
+        }
+      },
+      terminalProviderProtocolVersion,
+      25
+    )
+    await expect(firstStart).rejects.toMatchObject({ code: 'COMMAND_TIMED_OUT' })
+    const starting = await client.request<{
+      readonly sessions: readonly TerminalSessionSnapshot[]
+    }>('listSessions')
+    expect(starting.sessions).toEqual([])
+
+    processes.resolveStart(4343)
+    await vi.waitFor(async () => {
+      const recovered = await client.request<{
+        readonly sessions: readonly TerminalSessionSnapshot[]
+      }>('listSessions')
+      expect(recovered.sessions).toEqual([
+        expect.objectContaining({ sessionId: scope.sessionId, processId: 4343, status: 'running' })
+      ])
+    })
+    await expect(
+      client.request('startProcess', {
+        command: {
+          scope,
+          workingDirectory: '/work/app',
+          columns: 80,
+          rows: 24,
+          sessionKind: 'interactive'
+        }
+      })
+    ).resolves.toEqual({ processId: 4343 })
+    expect(processes.starts).toHaveLength(1)
     client.close()
   })
 
@@ -479,78 +575,16 @@ class RecordingProcessPort implements TerminalProcessPort {
   }
 }
 
-class TestProviderClient {
-  private readonly decoder = new TerminalProviderFrameDecoder()
-  private readonly responses = new Map<
-    string,
-    { readonly resolve: (value: unknown) => void; readonly reject: (error: unknown) => void }
-  >()
-  private readonly events: TerminalProviderEvent[] = []
+class DeferredStartProcessPort extends RecordingProcessPort {
+  private readonly startResult = deferred<{ readonly processId: number }>()
 
-  private constructor(
-    private readonly socket: Socket,
-    private readonly authToken: string
-  ) {
-    socket.on('data', (chunk) => {
-      for (const message of this.decoder.push(chunk)) this.accept(message)
-    })
+  override async start(command: StartTerminalProcessCommand) {
+    this.starts.push(command)
+    return this.startResult.promise
   }
 
-  static async connect(endpoint: string, authToken: string): Promise<TestProviderClient> {
-    const socket = connect(endpoint)
-    await new Promise<void>((resolve, reject) => {
-      socket.once('connect', resolve)
-      socket.once('error', reject)
-    })
-    return new TestProviderClient(socket, authToken)
-  }
-
-  request<T = void>(
-    method: string,
-    params?: unknown,
-    protocolVersion = terminalProviderProtocolVersion
-  ): Promise<T> {
-    const requestId = randomUUID()
-    this.socket.write(
-      encodeTerminalProviderFrame({
-        type: 'request',
-        protocolVersion,
-        requestId,
-        authToken: this.authToken,
-        method,
-        params
-      })
-    )
-    return new Promise<T>((resolve, reject) => {
-      this.responses.set(requestId, {
-        resolve: (value) => resolve(value as T),
-        reject
-      })
-    })
-  }
-
-  async waitForEvent(event: TerminalProviderEvent['event']): Promise<TerminalProviderEvent> {
-    await vi.waitFor(() =>
-      expect(this.events.some((candidate) => candidate.event === event)).toBe(true)
-    )
-    return this.events.find((candidate) => candidate.event === event) as TerminalProviderEvent
-  }
-
-  close(): void {
-    this.socket.destroy()
-  }
-
-  private accept(value: unknown): void {
-    const message = value as TerminalProviderResponse | TerminalProviderEvent
-    if (message.type === 'event') {
-      this.events.push(message)
-      return
-    }
-    const pending = this.responses.get(message.requestId)
-    if (!pending) return
-    this.responses.delete(message.requestId)
-    if (message.ok) pending.resolve(message.result)
-    else pending.reject(message.error)
+  resolveStart(processId: number): void {
+    this.startResult.resolve({ processId })
   }
 }
 
@@ -579,6 +613,21 @@ async function createAndStart(
   })
 }
 
+async function createModel(
+  client: TestProviderClient,
+  scope: ReturnType<typeof identityFor>
+): Promise<void> {
+  await client.request('createModel', {
+    command: {
+      identity: scope,
+      columns: 80,
+      rows: 24,
+      workingDirectory: '/work/app',
+      terminalSourceTheme: 'light'
+    }
+  })
+}
+
 function claimController(client: TestProviderClient, controllerId = 'controller-1') {
   return client.request<{ readonly controllerLeaseId: string }>('claimController', {
     controllerId,
@@ -587,15 +636,27 @@ function claimController(client: TestProviderClient, controllerId = 'controller-
 }
 
 function identity() {
+  return identityFor('1')
+}
+
+function identityFor(suffix: string) {
   return {
     projectId: 'project-1',
     projectDirectory: '/work/app',
     workspaceId: 'main',
     workspaceDirectory: '/work/app',
     gitBranch: 'main',
-    blockId: 'block-1',
-    sessionId: 'session-1',
-    runId: 'run-1',
+    blockId: `block-${suffix}`,
+    sessionId: `session-${suffix}`,
+    runId: `run-${suffix}`,
     generation: 1
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
 }

--- a/tests/integration/contexts/run/run.terminal-provider-shutdown.spec.ts
+++ b/tests/integration/contexts/run/run.terminal-provider-shutdown.spec.ts
@@ -78,7 +78,7 @@ describe('terminal provider application shutdown', () => {
     reattached.close()
   })
 
-  it('keeps ownership after a failed physical stop and rejects a replacement controller', async () => {
+  it('quarantines an unverified process without blocking a replacement controller', async () => {
     const processes = new ControlledProcessPort(new Set(['failed-stop']))
     const onExitRequested = vi.fn()
     server = createServer(processes, onExitRequested)
@@ -106,10 +106,12 @@ describe('terminal provider application shutdown', () => {
     })
     const reattached = await TestProviderClient.connect(endpoint)
     const health = await reattached.request<{ readonly controllerState: string }>('health')
-    expect(health.controllerState).toBe('releasing')
-    await expect(claimController(reattached, 'controller-2')).rejects.toMatchObject({
-      code: 'TERMINAL_PROVIDER_CONTROLLER_BUSY'
-    })
+    expect(health.controllerState).toBe('unclaimed')
+    await expect(claimController(reattached, 'controller-2')).resolves.toBeDefined()
+    const listed = await reattached.request<{
+      readonly sessions: readonly TerminalSessionSnapshot[]
+    }>('listSessions')
+    expect(listed.sessions).toEqual([])
     await expectNoCall(onExitRequested)
     reattached.close()
   })
@@ -169,6 +171,7 @@ class TestProviderClient {
     string,
     { readonly resolve: (value: unknown) => void; readonly reject: (error: unknown) => void }
   >()
+  private controllerLeaseId: string | undefined
 
   private constructor(private readonly socket: Socket) {
     socket.on('data', (chunk) => {
@@ -199,13 +202,25 @@ class TestProviderClient {
         protocolVersion: terminalProviderProtocolVersion,
         requestId,
         authToken: 'secret-token',
+        controllerLeaseId: this.controllerLeaseId,
         method,
         params
       })
     )
     return new Promise<T>((resolve, reject) => {
       this.responses.set(requestId, {
-        resolve: (value) => resolve(value as T),
+        resolve: (value) => {
+          if (
+            method === 'claimController' &&
+            typeof value === 'object' &&
+            value !== null &&
+            'controllerLeaseId' in value &&
+            typeof value.controllerLeaseId === 'string'
+          ) {
+            this.controllerLeaseId = value.controllerLeaseId
+          }
+          resolve(value as T)
+        },
         reject
       })
     })

--- a/tests/support/terminalProviderTestClient.ts
+++ b/tests/support/terminalProviderTestClient.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from 'node:crypto'
+import { connect, type Socket } from 'node:net'
+
+import {
+  encodeTerminalProviderFrame,
+  type TerminalProviderEvent,
+  TerminalProviderFrameDecoder,
+  type TerminalProviderResponse,
+  terminalProviderProtocolVersion
+} from '../../src/contexts/run/infrastructure/provider/TerminalProviderProtocol'
+
+export class TerminalProviderTestClient {
+  private readonly decoder = new TerminalProviderFrameDecoder()
+  private readonly responses = new Map<
+    string,
+    { readonly resolve: (value: unknown) => void; readonly reject: (error: unknown) => void }
+  >()
+  private readonly events: TerminalProviderEvent[] = []
+  private controllerLeaseId: string | undefined
+
+  private constructor(
+    private readonly socket: Socket,
+    private readonly authToken: string
+  ) {
+    socket.on('data', (chunk) => {
+      for (const message of this.decoder.push(chunk)) this.accept(message)
+    })
+  }
+
+  static async connect(endpoint: string, authToken: string): Promise<TerminalProviderTestClient> {
+    const socket = connect(endpoint)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('connect', resolve)
+      socket.once('error', reject)
+    })
+    return new TerminalProviderTestClient(socket, authToken)
+  }
+
+  request<T = void>(
+    method: string,
+    params?: unknown,
+    protocolVersion = terminalProviderProtocolVersion,
+    deadlineMs?: number
+  ): Promise<T> {
+    const requestId = randomUUID()
+    this.socket.write(
+      encodeTerminalProviderFrame({
+        type: 'request',
+        protocolVersion,
+        requestId,
+        authToken: this.authToken,
+        controllerLeaseId: this.controllerLeaseId,
+        method,
+        params,
+        deadlineMs
+      })
+    )
+    return new Promise<T>((resolve, reject) => {
+      this.responses.set(requestId, {
+        resolve: (value) => {
+          if (method === 'claimController' && isControllerClaim(value)) {
+            this.controllerLeaseId = value.controllerLeaseId
+          }
+          resolve(value as T)
+        },
+        reject
+      })
+    })
+  }
+
+  async waitForEvent(event: TerminalProviderEvent['event']): Promise<TerminalProviderEvent> {
+    await vi.waitFor(() =>
+      expect(this.events.some((candidate) => candidate.event === event)).toBe(true)
+    )
+    return this.events.find((candidate) => candidate.event === event) as TerminalProviderEvent
+  }
+
+  close(): void {
+    this.socket.destroy()
+  }
+
+  private accept(value: unknown): void {
+    const message = value as TerminalProviderResponse | TerminalProviderEvent
+    if (message.type === 'event') {
+      this.events.push(message)
+      return
+    }
+    const pending = this.responses.get(message.requestId)
+    if (!pending) return
+    this.responses.delete(message.requestId)
+    if (message.ok) pending.resolve(message.result)
+    else pending.reject(message.error)
+  }
+}
+
+function isControllerClaim(value: unknown): value is { readonly controllerLeaseId: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'controllerLeaseId' in value &&
+    typeof value.controllerLeaseId === 'string'
+  )
+}

--- a/tests/unit/contexts/run/run.terminal-provider-controller-lifecycle.spec.ts
+++ b/tests/unit/contexts/run/run.terminal-provider-controller-lifecycle.spec.ts
@@ -13,7 +13,6 @@ describe('terminal provider controller lifecycle', () => {
     const lifecycle = new TerminalProviderControllerLifecycle({
       createRelease: () => release.promise,
       hasLiveSessions: () => true,
-      hasUnsafeLiveSessions: () => false,
       isProcessAlive: (processId) => processId !== 101 || isFirstControllerAlive,
       onClaim: vi.fn(),
       onIdleWithoutLiveSessions: vi.fn()
@@ -50,7 +49,6 @@ describe('terminal provider controller lifecycle', () => {
     const lifecycle = new TerminalProviderControllerLifecycle({
       createRelease: () => release.promise,
       hasLiveSessions: () => true,
-      hasUnsafeLiveSessions: () => false,
       isProcessAlive: () => true,
       onClaim: vi.fn(),
       onIdleWithoutLiveSessions: vi.fn()
@@ -86,7 +84,6 @@ describe('terminal provider controller lifecycle', () => {
     const lifecycle = new TerminalProviderControllerLifecycle({
       createRelease: () => release.promise,
       hasLiveSessions: () => true,
-      hasUnsafeLiveSessions: () => false,
       isProcessAlive: () => true,
       onClaim: vi.fn(),
       onIdleWithoutLiveSessions: vi.fn()
@@ -111,6 +108,27 @@ describe('terminal provider controller lifecycle', () => {
     })
     await vi.waitFor(() => expect(lifecycle.state.kind).toBe('unclaimed'))
 
+    expect(lifecycle.claim(replacementSocket, 'controller-2', 202)).toEqual({
+      controllerLeaseId: expect.any(String)
+    })
+  })
+
+  it('expires an unresponsive release before admitting a replacement controller', async () => {
+    const firstSocket = { destroyed: false } as Socket
+    const replacementSocket = {} as Socket
+    const lifecycle = new TerminalProviderControllerLifecycle({
+      createRelease: () => new Promise(() => undefined),
+      hasLiveSessions: () => true,
+      isProcessAlive: () => true,
+      releaseDeadlineMs: 25,
+      onClaim: vi.fn(),
+      onIdleWithoutLiveSessions: vi.fn()
+    })
+
+    lifecycle.claim(firstSocket, 'controller-1', 101)
+    lifecycle.handleSocketClose(firstSocket)
+
+    await vi.waitFor(() => expect(lifecycle.state.kind).toBe('unclaimed'))
     expect(lifecycle.claim(replacementSocket, 'controller-2', 202)).toEqual({
       controllerLeaseId: expect.any(String)
     })

--- a/tests/unit/contexts/run/run.terminal-provider-shutdown-coordinator.spec.ts
+++ b/tests/unit/contexts/run/run.terminal-provider-shutdown-coordinator.spec.ts
@@ -163,6 +163,38 @@ describe('terminal provider shutdown coordinator', () => {
       failureCount: 1
     })
   })
+
+  it('bounds a checkpoint that never settles and continues releasing the controller', async () => {
+    const retained = createSession('blocked-checkpoint', {
+      retentionPolicy: 'keep-after-application-exit'
+    })
+    vi.mocked(retained.persistence.checkpoint).mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    const stop = vi.fn(async () => undefined)
+    const retireSession = vi.fn(async () => undefined)
+    const onFailure = vi.fn()
+    const coordinator = new TerminalProviderShutdownCoordinator({
+      operationDeadlineMs: 25,
+      processes: { stop },
+      retireSession,
+      onFailure
+    })
+
+    const result = await coordinator.release({
+      releaseId: 'release-blocked-checkpoint',
+      sessions: [retained]
+    })
+
+    expect(stop).toHaveBeenCalledWith('blocked-checkpoint')
+    expect(retireSession).toHaveBeenCalledWith(retained.snapshot)
+    expect(onFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'COMMAND_TIMED_OUT' }),
+      retained,
+      'checkpoint'
+    )
+    expect(result).toMatchObject({ outcome: 'partial-failure', retiredSessionCount: 1 })
+  })
 })
 
 function createSession(


### PR DESCRIPTION
## Summary

- isolate Provider RPC work into control, settings, per-session, and method-global lanes so one blocked terminal cannot stall health checks or unrelated sessions
- add request deadlines, controller lease fencing, bounded shutdown and checkpoint handling, and quarantine for sessions whose physical stop cannot be verified
- make terminal/model startup reconciliation idempotent and prevent late persistence writes from resurrecting retired sessions
- add bounded rotating diagnostics for the Electron main process and terminal Provider without recording terminal content or environment data

## Root cause

A slow or stuck terminal tail/checkpoint could monopolize the Provider connection. Client-side timeouts removed only the pending request, while controller release and shutdown still waited without a hard bound. This left the runtime socket alive but unusable, so restarting or creating terminals could keep reporting that the terminal runtime was unavailable.

## Verification

- pnpm test:core
- pnpm check:quality
- pnpm build
- pnpm test:e2e
- pnpm vitest run --config vitest.e2e.config.ts --no-file-parallelism tests/e2e/terminal-runtime-recovery.e2e.spec.ts tests/e2e/terminal-workflows.e2e.spec.ts
