### PR TITLE
feat: polish workspace selection motion

### DIFF
--- a/src/presentation/app-shell/ProjectSidebar.tsx
+++ b/src/presentation/app-shell/ProjectSidebar.tsx
@@ -14,6 +14,7 @@ import { useProjectSidebarBranchWorkspaceForm } from './useProjectSidebarBranchW
 import { useI18n } from './i18n/useI18n'
 import { useProjectSidebarReorder } from './useProjectSidebarReorder'
 import { useProjectSidebarMotion } from './useProjectSidebarMotion'
+import { useSelectionIndicatorMotion } from './useSelectionMotion'
 import { useOutsidePointerDismiss } from './useOutsidePointerDismiss'
 import { TooltipLabel } from './Tooltip'
 import { WorkspaceRowMenu } from './WorkspaceRowMenu'
@@ -197,6 +198,11 @@ function ProjectCard({
 }: ProjectCardProps) {
   const { t } = useI18n()
   const isCurrentProject = currentWorkbench?.project.id === workbench.project.id
+  const currentWorkspaceId = isCurrentProject
+    ? (workbench.project.workspaces.find((workspace) => workspace.isCurrent)?.workspaceId ?? null)
+    : null
+  const [workspaceSelectionContainerRef, workspaceSelectionIndicatorRef] =
+    useSelectionIndicatorMotion(currentWorkspaceId ?? '')
   const [isBranchSelectorOpen, setIsBranchSelectorOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(true)
   const [branchSearchQuery, setBranchSearchQuery] = useState('')
@@ -377,7 +383,15 @@ function ProjectCard({
         inert={!isExpanded ? true : undefined}
       >
         <div className="project-card__disclosure-content">
-          <div id={workspaceListId} className="workspace-list">
+          <div ref={workspaceSelectionContainerRef} id={workspaceListId} className="workspace-list">
+            {currentWorkspaceId ? (
+              <span
+                ref={workspaceSelectionIndicatorRef}
+                className="selection-motion-indicator workspace-list__selection"
+                data-selection-motion-target={currentWorkspaceId}
+                aria-hidden="true"
+              />
+            ) : null}
             {workbench.project.workspaces.map((workspace) => {
               const isActiveWorkspace = workspace.isCurrent && isCurrentProject
               const boundBranchName = workspace.gitBranch ?? workspace.displayName
@@ -404,6 +418,7 @@ function ProjectCard({
               return (
                 <div
                   className="workspace-group"
+                  data-selection-motion-option={workspace.workspaceId}
                   key={workspace.workspaceId}
                   ref={isDefaultWorkspace ? branchSelectorRootRef : undefined}
                 >

--- a/src/presentation/app-shell/selectionMotion.ts
+++ b/src/presentation/app-shell/selectionMotion.ts
@@ -18,12 +18,32 @@ export interface SelectionMotionTarget {
 }
 
 export interface SelectionIndicatorMotionRoot {
+  readonly animate?: Element['animate']
   readonly style: Pick<CSSStyleDeclaration, 'removeProperty' | 'setProperty'>
   readonly removeAttribute: (name: string) => unknown
   readonly setAttribute: (name: string, value: string) => unknown
 }
 
+export interface SelectionIndicatorAnimationFrame {
+  readonly offset: number
+  readonly transform: string
+}
+
+export interface SelectionIndicatorAnimation {
+  readonly cancel: () => void
+  readonly finished: Promise<unknown>
+}
+
+export interface SelectionIndicatorAnimationDriver {
+  readonly animate: (
+    root: SelectionIndicatorMotionRoot,
+    frames: readonly SelectionIndicatorAnimationFrame[],
+    options: KeyframeAnimationOptions
+  ) => SelectionIndicatorAnimation | null
+}
+
 interface SelectionIndicatorMotionControllerOptions {
+  readonly animationDriver?: SelectionIndicatorAnimationDriver
   readonly scheduler?: SpringProgressMotionFrameScheduler
 }
 
@@ -58,6 +78,8 @@ const heightProperty = '--cc-selection-motion-height'
 const progressProperty = '--cc-selection-motion-progress'
 const stateAttribute = 'data-selection-motion-state'
 const positionThresholds = { speed: 0.02, value: 0.01 }
+const compositorSampleSeconds = 1 / 120
+const maximumCompositorSampleCount = 240
 const browserFrameScheduler: SpringProgressMotionFrameScheduler = {
   cancelFrame: (frameId) => {
     if (typeof window.cancelAnimationFrame === 'function') window.cancelAnimationFrame(frameId)
@@ -71,25 +93,46 @@ const browserFrameScheduler: SpringProgressMotionFrameScheduler = {
     return window.setTimeout(() => callback(window.performance.now()), 1000 / 60)
   }
 }
+const browserAnimationDriver: SelectionIndicatorAnimationDriver = {
+  animate: (root, frames, options) => {
+    if (!root.animate) return null
+    const keyframes: Keyframe[] = frames.map(({ offset, transform }) => ({ offset, transform }))
+    return root.animate.call(root, keyframes, options)
+  }
+}
 
 export function createSelectionIndicatorMotionController({
+  animationDriver = browserAnimationDriver,
   scheduler = browserFrameScheduler
 }: SelectionIndicatorMotionControllerOptions = {}): SelectionIndicatorMotionController {
   let root: SelectionIndicatorMotionRoot | null = null
   let target: SelectionMotionTarget | null = null
   let x: SpringAxis = { value: 0, velocity: 0 }
   let y: SpringAxis = { value: 0, velocity: 0 }
+  let activeAnimation: SelectionIndicatorAnimation | null = null
+  let animationRevision = 0
   let animationFrameId: number | null = null
-  let lastFrameTimestamp = scheduler.now()
+  let lastPresentationTimestamp = scheduler.now()
 
   const cancelFrame = (): void => {
     if (animationFrameId !== null) scheduler.cancelFrame(animationFrameId)
     animationFrameId = null
   }
 
+  const cancelActiveAnimation = (): void => {
+    animationRevision += 1
+    const animation = activeAnimation
+    activeAnimation = null
+    animation?.cancel()
+  }
+
+  const cancelMotion = (): void => {
+    cancelFrame()
+    cancelActiveAnimation()
+  }
+
   const scheduleFrame = (): void => {
     if (animationFrameId !== null) return
-    lastFrameTimestamp = scheduler.now()
     animationFrameId = scheduler.requestFrame(advanceFrame)
   }
 
@@ -98,17 +141,24 @@ export function createSelectionIndicatorMotionController({
     isSpringAxisSettled(x, target.x, positionThresholds) &&
     isSpringAxisSettled(y, target.y, positionThresholds)
 
-  function advanceFrame(timestamp: number): void {
-    animationFrameId = null
-    if (!root || !target) return
-    const elapsedSeconds = Math.max(0, (timestamp - lastFrameTimestamp) / 1000)
-    lastFrameTimestamp = timestamp
+  const advancePresentation = (timestamp: number): void => {
+    if (!target) return
+    const elapsedSeconds = Math.max(0, (timestamp - lastPresentationTimestamp) / 1000)
+    lastPresentationTimestamp = timestamp
     x = advanceSpringAxis(x, target.x, selectionMotionDynamics, elapsedSeconds)
     y = advanceSpringAxis(y, target.y, selectionMotionDynamics, elapsedSeconds)
 
+    if (!settled()) return
+    x = { value: target.x, velocity: 0 }
+    y = { value: target.y, velocity: 0 }
+  }
+
+  function advanceFrame(timestamp: number): void {
+    animationFrameId = null
+    if (!root || !target) return
+    advancePresentation(timestamp)
+
     if (settled()) {
-      x = { value: target.x, velocity: 0 }
-      y = { value: target.y, velocity: 0 }
       presentIndicator(root, target, x, y, 'settled')
       return
     }
@@ -117,16 +167,70 @@ export function createSelectionIndicatorMotionController({
     scheduleFrame()
   }
 
+  const beginMotion = (): void => {
+    if (!root || !target) return
+    presentIndicator(root, target, x, y, 'moving')
+    const sampled = sampleSelectionIndicatorMotion(x, y, target)
+    let animation: SelectionIndicatorAnimation | null = null
+
+    try {
+      animation = animationDriver.animate(root, sampled.frames, {
+        duration: sampled.durationMilliseconds,
+        easing: 'linear',
+        fill: 'both'
+      })
+    } catch {
+      animation = null
+    }
+
+    lastPresentationTimestamp = scheduler.now()
+    if (!animation) {
+      scheduleFrame()
+      return
+    }
+
+    activeAnimation = animation
+    animationRevision += 1
+    const revision = animationRevision
+    void animation.finished.then(
+      () => {
+        if (activeAnimation !== animation || animationRevision !== revision || !root || !target) {
+          return
+        }
+
+        activeAnimation = null
+        x = { value: target.x, velocity: 0 }
+        y = { value: target.y, velocity: 0 }
+        presentIndicator(root, target, x, y, 'settled')
+        animation.cancel()
+      },
+      () => {
+        if (activeAnimation !== animation || animationRevision !== revision || !root || !target) {
+          return
+        }
+
+        activeAnimation = null
+        advancePresentation(scheduler.now())
+        if (settled()) {
+          presentIndicator(root, target, x, y, 'settled')
+          return
+        }
+        presentIndicator(root, target, x, y, 'moving')
+        scheduleFrame()
+      }
+    )
+  }
+
   return {
     dispose: () => {
-      cancelFrame()
+      cancelMotion()
       if (root) clearIndicator(root)
       root = null
       target = null
     },
     targetChanged: (nextRoot, nextTarget, intent) => {
       if (nextRoot !== root) {
-        cancelFrame()
+        cancelMotion()
         if (root) clearIndicator(root)
         root = nextRoot
         target = null
@@ -134,28 +238,31 @@ export function createSelectionIndicatorMotionController({
       if (!root) return
 
       if (!target || intent.reducedMotion) {
-        cancelFrame()
+        cancelMotion()
         target = nextTarget
         x = { value: nextTarget.x, velocity: 0 }
         y = { value: nextTarget.y, velocity: 0 }
+        lastPresentationTimestamp = scheduler.now()
         presentIndicator(root, target, x, y, 'settled')
         return
       }
 
+      const retargetTimestamp = scheduler.now()
+      advancePresentation(retargetTimestamp)
+      cancelMotion()
       x = retargetSpringAxis(x, nextTarget.x, 'toward-target-only')
       y = retargetSpringAxis(y, nextTarget.y, 'toward-target-only')
       target = nextTarget
+      lastPresentationTimestamp = retargetTimestamp
 
       if (settled()) {
-        cancelFrame()
         x = { value: nextTarget.x, velocity: 0 }
         y = { value: nextTarget.y, velocity: 0 }
         presentIndicator(root, target, x, y, 'settled')
         return
       }
 
-      presentIndicator(root, target, x, y, 'moving')
-      scheduleFrame()
+      beginMotion()
     }
   }
 }
@@ -205,6 +312,63 @@ function clearIndicator(root: SelectionIndicatorMotionRoot): void {
   root.style.removeProperty(widthProperty)
   root.style.removeProperty(heightProperty)
   root.removeAttribute(stateAttribute)
+}
+
+function sampleSelectionIndicatorMotion(
+  initialX: SpringAxis,
+  initialY: SpringAxis,
+  target: SelectionMotionTarget
+): {
+  readonly durationMilliseconds: number
+  readonly frames: readonly SelectionIndicatorAnimationFrame[]
+} {
+  let sampledX = initialX
+  let sampledY = initialY
+  const positions: { readonly x: number; readonly y: number }[] = [
+    { x: initialX.value, y: initialY.value }
+  ]
+
+  for (let sample = 0; sample < maximumCompositorSampleCount; sample += 1) {
+    sampledX = advanceSpringAxis(
+      sampledX,
+      target.x,
+      selectionMotionDynamics,
+      compositorSampleSeconds
+    )
+    sampledY = advanceSpringAxis(
+      sampledY,
+      target.y,
+      selectionMotionDynamics,
+      compositorSampleSeconds
+    )
+    const hasSettled =
+      isSpringAxisSettled(sampledX, target.x, positionThresholds) &&
+      isSpringAxisSettled(sampledY, target.y, positionThresholds)
+    positions.push(hasSettled ? { x: target.x, y: target.y } : sampledPosition(sampledX, sampledY))
+    if (hasSettled) break
+  }
+
+  const finalPosition = positions.at(-1)
+  if (finalPosition?.x !== target.x || finalPosition.y !== target.y) {
+    positions.push({ x: target.x, y: target.y })
+  }
+
+  const intervalCount = positions.length - 1
+  return {
+    durationMilliseconds: intervalCount * compositorSampleSeconds * 1000,
+    frames: positions.map((position, index) => ({
+      offset: intervalCount === 0 ? 1 : index / intervalCount,
+      transform: toSelectionIndicatorTransform(position.x, position.y)
+    }))
+  }
+}
+
+function sampledPosition(x: SpringAxis, y: SpringAxis): { readonly x: number; readonly y: number } {
+  return { x: x.value, y: y.value }
+}
+
+function toSelectionIndicatorTransform(x: number, y: number): string {
+  return `translate3d(${round(x)}px, ${round(y)}px, 0)`
 }
 
 function emptyCallback(): void {}

--- a/src/presentation/app-shell/styles/project-sidebar.css
+++ b/src/presentation/app-shell/styles/project-sidebar.css
@@ -368,10 +368,12 @@
 }
 
 .workspace-list {
+  position: relative;
   min-height: 0;
   margin-left: 9px;
   border-left: 1px solid var(--cc-border);
   padding: 2px 0 0 9px;
+  isolation: isolate;
   transform: translateY(0);
   transition: transform var(--cc-motion-duration-surface) var(--cc-easing-standard);
 }
@@ -394,6 +396,7 @@
 
 .workspace-group {
   position: relative;
+  z-index: 1;
 }
 
 .workspace-group + .workspace-group {
@@ -425,6 +428,16 @@
   background: var(--cc-primary-soft);
   color: var(--cc-primary-hover);
   font-weight: 620;
+}
+
+.workspace-list[data-selection-motion-ready='true'] .workspace-row--active,
+.workspace-list[data-selection-motion-ready='true'] .workspace-row--active:hover,
+.workspace-list[data-selection-motion-ready='true'] .workspace-row--active:focus-within {
+  background: transparent;
+}
+
+.workspace-list:not([data-selection-motion-ready='true']) .workspace-row--active {
+  background: var(--cc-primary-soft);
 }
 
 .default-branch-selector {

--- a/src/presentation/app-shell/styles/selection-motion.css
+++ b/src/presentation/app-shell/styles/selection-motion.css
@@ -29,6 +29,12 @@
   content: '';
 }
 
+.workspace-list__selection {
+  z-index: 0;
+  border-radius: 7px;
+  background: var(--cc-primary-soft);
+}
+
 .application-settings-navigation:not([data-selection-motion-ready='true'])
   button[aria-current='page'] {
   background: var(--cc-primary-wash);

--- a/tests/unit/presentation/project-sidebar.navigation-semantics.spec.tsx
+++ b/tests/unit/presentation/project-sidebar.navigation-semantics.spec.tsx
@@ -4,6 +4,96 @@ import { ProjectSidebar } from '../../../src/presentation/app-shell/ProjectSideb
 import { createWorkbenchSnapshot } from '../../fixtures/presentation/appShellFixtures'
 
 describe('project sidebar navigation semantics', () => {
+  it('moves one shared selection material between workspaces while semantic selection updates immediately', () => {
+    const createWorkspaceWorkbench = (currentWorkspaceId: string) =>
+      createWorkbenchSnapshot('/tmp/motion-project', 'motion-project', {
+        workspaceId: currentWorkspaceId,
+        workspaces: [
+          {
+            workspaceId: 'main',
+            workspaceKind: 'default',
+            displayName: 'main',
+            directory: '/tmp/motion-project',
+            gitBranch: 'main',
+            isCurrent: currentWorkspaceId === 'main'
+          },
+          {
+            workspaceId: 'feature',
+            workspaceKind: 'linked-worktree',
+            displayName: 'feat/like',
+            directory: '/tmp/motion-project-feature',
+            gitBranch: 'feat/like',
+            isCurrent: currentWorkspaceId === 'feature'
+          }
+        ]
+      })
+    const offsetWidth = vi
+      .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.hasAttribute('data-selection-motion-option') ? 224 : 0
+      })
+    const offsetHeight = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.hasAttribute('data-selection-motion-option') ? 32 : 0
+      })
+    const offsetTop = vi
+      .spyOn(HTMLElement.prototype, 'offsetTop', 'get')
+      .mockImplementation(function (this: HTMLElement) {
+        return this.dataset.selectionMotionOption === 'feature' ? 34 : 0
+      })
+
+    try {
+      const mainWorkbench = createWorkspaceWorkbench('main')
+      const props = {
+        currentWorkbench: mainWorkbench,
+        isDesktopRuntime: true,
+        onAddProject: vi.fn(),
+        onArchiveBranchWorkspace: vi.fn(),
+        onCheckoutMainBranch: vi.fn(),
+        onCreateBranchWorkspace: vi.fn(),
+        onRemoveProject: vi.fn(),
+        onReorderProject: vi.fn(),
+        onSelectWorkspace: vi.fn(),
+        workbenches: [mainWorkbench]
+      }
+      const { rerender } = render(<ProjectSidebar {...props} />)
+      const workspaceList = document.querySelector('.workspace-list')
+      const indicator = workspaceList?.querySelector('.workspace-list__selection')
+
+      expect(workspaceList).toHaveAttribute('data-selection-motion-ready', 'true')
+      expect(indicator).toHaveAttribute('data-selection-motion-target', 'main')
+      expect(indicator).toHaveAttribute('data-selection-motion-state', 'settled')
+      expect(screen.getByRole('button', { name: 'main 默认工作区' })).toHaveAttribute(
+        'aria-current',
+        'page'
+      )
+
+      const featureWorkbench = createWorkspaceWorkbench('feature')
+      rerender(
+        <ProjectSidebar
+          {...props}
+          currentWorkbench={featureWorkbench}
+          workbenches={[featureWorkbench]}
+        />
+      )
+
+      expect(indicator).toHaveAttribute('data-selection-motion-target', 'feature')
+      expect(indicator).toHaveAttribute('data-selection-motion-state', 'moving')
+      expect(screen.getByRole('button', { name: 'feat/like 独立工作区' })).toHaveAttribute(
+        'aria-current',
+        'page'
+      )
+      expect(screen.getByRole('button', { name: 'main 默认工作区' })).not.toHaveAttribute(
+        'aria-current'
+      )
+    } finally {
+      offsetWidth.mockRestore()
+      offsetHeight.mockRestore()
+      offsetTop.mockRestore()
+    }
+  })
+
   it('places a compact add-project action at the far edge of the projects heading', () => {
     const workbench = createWorkbenchSnapshot('/tmp/alpha-project', 'alpha-project')
     const onAddProject = vi.fn()

--- a/tests/unit/presentation/selection-motion-styles.spec.ts
+++ b/tests/unit/presentation/selection-motion-styles.spec.ts
@@ -9,6 +9,7 @@ const selectionStyles = readStyles('selection-motion.css')
 const settingsStyles = readStyles('application-settings.css')
 const agentSettingsStyles = readStyles('agent-settings.css')
 const libraryStyles = readStyles('block-template-library.css')
+const projectSidebarStyles = readStyles('project-sidebar.css')
 const themeStyles = readStyles('theme-settings.css')
 
 describe('selection motion styles', () => {
@@ -24,12 +25,15 @@ describe('selection motion styles', () => {
     expect(indicatorRule).not.toContain('transition:')
   })
 
-  it('uses the shared material in settings navigation and template scope tabs', () => {
+  it('uses the shared material in settings navigation, workspace rows, and template scope tabs', () => {
     expect(selectionStyles).toContain('.application-settings-navigation__selection')
+    expect(selectionStyles).toContain('.workspace-list__selection')
     expect(libraryStyles).toContain('.block-template-library-tabs__selection')
     expect(readRule(settingsStyles, '.application-settings-navigation button')).toContain(
       'z-index: 1;'
     )
+    expect(readRule(projectSidebarStyles, '.workspace-list')).toContain('position: relative;')
+    expect(readRule(projectSidebarStyles, '.workspace-group')).toContain('z-index: 1;')
     expect(readRule(libraryStyles, '.block-template-library-tabs button')).toContain('z-index: 1;')
   })
 
@@ -38,6 +42,9 @@ describe('selection motion styles', () => {
       ".application-settings-navigation:not([data-selection-motion-ready='true'])"
     )
     expect(selectionStyles).toContain("button[aria-current='page']::before")
+    expect(projectSidebarStyles).toContain(
+      ".workspace-list:not([data-selection-motion-ready='true'])"
+    )
   })
 
   it('drives settings switches and stateful choices from shared spring progress', () => {

--- a/tests/unit/presentation/selection-motion.spec.ts
+++ b/tests/unit/presentation/selection-motion.spec.ts
@@ -1,6 +1,9 @@
 import {
   createSelectionIndicatorMotionController,
   selectionMotionDynamics,
+  type SelectionIndicatorAnimation,
+  type SelectionIndicatorAnimationDriver,
+  type SelectionIndicatorAnimationFrame,
   type SelectionIndicatorMotionRoot,
   type SelectionMotionTarget
 } from '../../../src/presentation/app-shell/selectionMotion'
@@ -76,6 +79,117 @@ describe('selection motion', () => {
     expect(root.attributes.get('data-selection-motion-state')).toBe('settled')
     expect(scheduler.pendingFrames()).toBe(0)
   })
+
+  it('hands sampled transform keyframes to the browser animation driver', async () => {
+    const scheduler = createFrameScheduler()
+    const animationDriver = createAnimationDriver()
+    const root = createRoot()
+    const controller = createSelectionIndicatorMotionController({ animationDriver, scheduler })
+
+    controller.targetChanged(root, target(0, 0, 180, 40), { reducedMotion: false })
+    controller.targetChanged(root, target(0, 132, 180, 40), { reducedMotion: false })
+
+    const animation = animationDriver.animations[0]
+    expect(animation).toBeDefined()
+    expect(animation?.frames.length).toBeGreaterThan(2)
+    expect(animation?.frames[0]).toEqual({ offset: 0, transform: 'translate3d(0px, 0px, 0)' })
+    expect(animation?.frames.at(-1)).toEqual({
+      offset: 1,
+      transform: 'translate3d(0px, 132px, 0)'
+    })
+    expect(animation?.options).toMatchObject({ easing: 'linear', fill: 'both' })
+    expect(animation?.options.duration).toBeGreaterThan(0)
+    expect(scheduler.pendingFrames()).toBe(0)
+    expect(root.attributes.get('data-selection-motion-state')).toBe('moving')
+
+    animation?.finish()
+    await settlePromises()
+
+    expect(readNumber(root, '--cc-selection-motion-y')).toBe(132)
+    expect(root.attributes.get('data-selection-motion-state')).toBe('settled')
+  })
+
+  it('redirects compositor motion from its analytic presentation and ignores stale completion', async () => {
+    const scheduler = createFrameScheduler()
+    const animationDriver = createAnimationDriver()
+    const root = createRoot()
+    const controller = createSelectionIndicatorMotionController({ animationDriver, scheduler })
+
+    controller.targetChanged(root, target(0, 0), { reducedMotion: false })
+    controller.targetChanged(root, target(0, 132), { reducedMotion: false })
+    scheduler.elapse(72)
+    controller.targetChanged(root, target(0, 44), { reducedMotion: false })
+
+    const firstAnimation = animationDriver.animations[0]
+    const redirectedAnimation = animationDriver.animations[1]
+    const redirectedStartY = readTransformAxis(redirectedAnimation?.frames[0], 'y')
+    expect(firstAnimation?.cancelled()).toBe(true)
+    expect(redirectedStartY).toBeGreaterThan(0)
+    expect(redirectedStartY).toBeLessThan(132)
+    expect(Math.abs(readTransformAxis(redirectedAnimation?.frames[1], 'y') - 44)).toBeLessThan(
+      Math.abs(redirectedStartY - 44)
+    )
+
+    firstAnimation?.finish()
+    await settlePromises()
+    expect(root.attributes.get('data-selection-motion-state')).toBe('moving')
+
+    redirectedAnimation?.finish()
+    await settlePromises()
+    expect(readNumber(root, '--cc-selection-motion-y')).toBe(44)
+    expect(root.attributes.get('data-selection-motion-state')).toBe('settled')
+  })
+
+  it('cancels compositor motion when reduced motion takes over', () => {
+    const scheduler = createFrameScheduler()
+    const animationDriver = createAnimationDriver()
+    const root = createRoot()
+    const controller = createSelectionIndicatorMotionController({ animationDriver, scheduler })
+
+    controller.targetChanged(root, target(0, 0), { reducedMotion: false })
+    controller.targetChanged(root, target(120, 0), { reducedMotion: false })
+    scheduler.elapse(40)
+    controller.targetChanged(root, target(240, 0), { reducedMotion: true })
+
+    expect(animationDriver.animations[0]?.cancelled()).toBe(true)
+    expect(animationDriver.animations).toHaveLength(1)
+    expect(readNumber(root, '--cc-selection-motion-x')).toBe(240)
+    expect(root.attributes.get('data-selection-motion-state')).toBe('settled')
+  })
+
+  it('falls back to requestAnimationFrame when browser animation creation fails', () => {
+    const scheduler = createFrameScheduler()
+    const animationDriver: SelectionIndicatorAnimationDriver = {
+      animate: () => {
+        throw new Error('animation unavailable')
+      }
+    }
+    const root = createRoot()
+    const controller = createSelectionIndicatorMotionController({ animationDriver, scheduler })
+
+    controller.targetChanged(root, target(0, 0), { reducedMotion: false })
+    controller.targetChanged(root, target(0, 132), { reducedMotion: false })
+
+    expect(scheduler.pendingFrames()).toBe(1)
+    scheduler.advanceUntilIdle()
+    expect(readNumber(root, '--cc-selection-motion-y')).toBe(132)
+    expect(root.attributes.get('data-selection-motion-state')).toBe('settled')
+  })
+
+  it('cancels compositor work and clears presentation when disposed', () => {
+    const scheduler = createFrameScheduler()
+    const animationDriver = createAnimationDriver()
+    const root = createRoot()
+    const controller = createSelectionIndicatorMotionController({ animationDriver, scheduler })
+
+    controller.targetChanged(root, target(0, 0), { reducedMotion: false })
+    controller.targetChanged(root, target(0, 132), { reducedMotion: false })
+    controller.dispose()
+
+    expect(animationDriver.animations[0]?.cancelled()).toBe(true)
+    expect(root.attributes.has('data-selection-motion-state')).toBe(false)
+    expect(root.properties.size).toBe(0)
+  })
 })
 
 function target(x: number, y: number, width = 100, height = 32): SelectionMotionTarget {
@@ -113,6 +227,7 @@ function createRoot(): SelectionIndicatorMotionRoot & {
 function createFrameScheduler(): SpringProgressMotionFrameScheduler & {
   readonly advanceNextFrame: (milliseconds?: number) => void
   readonly advanceUntilIdle: () => void
+  readonly elapse: (milliseconds: number) => void
   readonly pendingFrames: () => number
 } {
   let nextFrameId = 1
@@ -130,6 +245,9 @@ function createFrameScheduler(): SpringProgressMotionFrameScheduler & {
       for (let frame = 0; frame < 240 && callbacks.size > 0; frame += 1) advanceNextFrame()
     },
     cancelFrame: (frameId) => callbacks.delete(frameId),
+    elapse: (milliseconds) => {
+      now += milliseconds
+    },
     now: () => now,
     pendingFrames: () => callbacks.size,
     requestFrame: (callback) => {
@@ -139,4 +257,53 @@ function createFrameScheduler(): SpringProgressMotionFrameScheduler & {
       return frameId
     }
   }
+}
+
+interface RecordedAnimation {
+  readonly cancelled: () => boolean
+  readonly finish: () => void
+  readonly frames: readonly SelectionIndicatorAnimationFrame[]
+  readonly options: KeyframeAnimationOptions
+}
+
+function createAnimationDriver(): SelectionIndicatorAnimationDriver & {
+  readonly animations: RecordedAnimation[]
+} {
+  const animations: RecordedAnimation[] = []
+  return {
+    animations,
+    animate: (_root, frames, options) => {
+      let isCancelled = false
+      let finish = (): void => undefined
+      const finished = new Promise<void>((resolve) => {
+        finish = resolve
+      })
+      const animation: SelectionIndicatorAnimation = {
+        cancel: () => {
+          isCancelled = true
+        },
+        finished
+      }
+      animations.push({
+        cancelled: () => isCancelled,
+        finish,
+        frames,
+        options
+      })
+      return animation
+    }
+  }
+}
+
+function readTransformAxis(
+  frame: SelectionIndicatorAnimationFrame | undefined,
+  axis: 'x' | 'y'
+): number {
+  const match = frame?.transform.match(/translate3d\(([-\d.]+)px, ([-\d.]+)px, 0\)/)
+  return Number.parseFloat(match?.[axis === 'x' ? 1 : 2] ?? '0')
+}
+
+async function settlePromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
 }


### PR DESCRIPTION
## 改动摘要

- 为分支工作区侧栏加入与设置导航一致的共享选择指示器动效。
- 将共享选择位移动效改为 WAAPI `transform` 关键帧播放，使画布负载较高时可由合成线程持续推进。
- 保留临界阻尼轨迹、快速重定向、减少动态效果和 RAF 回退行为。

## 背景与目标

切换分支工作区时，侧栏原本只有选中状态跳变；加入动效后，如果画布包含较多终端、Agent 或连线，主线程同步更新会阻塞逐帧 JavaScript 动画。本次只优化侧栏选择反馈，不改变工作区切换或画布状态语义。

## 影响范围

- Presentation：项目侧栏、共享 selection motion 及样式。
- Tests：侧栏导航语义、共享动效驱动与样式规则。
- 不涉及业务限界上下文、IPC、持久化或跨上下文事实来源。

## 验证

- `pnpm pre-commit`
- 单元测试：378 个文件、2154 个测试通过。
- 集成测试：220 个通过、17 个跳过。
- 契约测试：108 个通过。
- Electron E2E：16 个文件、48 个场景通过。

## 风险与限制

- WAAPI 不可用或创建失败时会回退到现有 RAF 路径。
- 合成线程播放可减少动画过程中的掉帧；极端主线程长任务仍可能延迟动效首次启动。
- 本次没有拆分侧栏反馈状态与画布工作台状态。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 我已遵循仓库路由规则和开发协作规范。
- [x] 行为变化时，我已新增或更新最低有效层级的测试。
- [x] 稳定行为变化时，我已更新负责该事实的文档（本次仅调整视觉动效，不改变稳定产品语义，无需文档更新）。
- [x] 我已运行要求的验证命令并如实报告失败。
- [x] 我已移除凭据、私有数据和敏感终端输出。
