### PR TITLE
chore(release): bump version to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",


### PR DESCRIPTION
## Summary

- bump the CleanCode package version from 0.1.11 to 0.1.12
- prepare the matching v0.1.12 Preview release tag

## Validation

- parsed package.json and verified version is 0.1.12
- git diff --check

Per the repository release-only version bump policy, pnpm pre-commit and a local package build are not required for this metadata-only change.