### PR TITLE
fix: keep Electron dev startup out of browser

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
   renderer: {
     root: '.',
     plugins: [react()],
+    server: {
+      open: false
+    },
     build: {
       rollupOptions: {
         input: resolve(__dirname, 'index.html')


### PR DESCRIPTION
## 改动摘要

- 在 renderer 的 Vite 开发服务器配置中显式设置 server.open 为 false。
- 保持 electron-vite dev 启动真实 Electron 应用，localhost 只作为后台 renderer 服务。

## 背景与目标

开发启动应始终进入 Electron 桌面应用，不应由 Vite 自动唤起 Safari、Chrome 等外部浏览器，避免把仅有 UI 的浏览器预览误认为真实应用运行时。

## 影响范围

不涉及业务限界上下文。仅影响 platform 构建配置 electron.vite.config.ts，不修改 preload、IPC、PTY、Agent 或用户主动打开外部链接的行为。

## 验证

- 解析 electron-vite 配置，确认 renderer.server.open=false。
- 使用隔离临时 profile 执行 pnpm dev，确认 Electron 主进程与 renderer 启动；未打开或访问浏览器。
- pnpm build
- VITEST_MAX_WORKERS=1 pnpm pre-commit
  - Unit：389 个文件、2239 项通过
  - Integration：39 个文件、228 项通过；5 个文件、20 项按平台跳过
  - Contract：19 个文件、112 项通过
  - Electron E2E：16 个文件、49 项通过

## 风险与限制

- Vite localhost 服务仍会在开发模式后台运行，这是 Electron renderer 的加载来源。
- 用户显式点击终端链接或打开外部服务地址时，系统浏览器仍会正常打开。
- 常规并行门禁的 Agent terminal activity integration 曾两次触发固定 5 秒超时；目标文件单独复跑 7/7 通过，最终完整门禁使用 Vitest 官方单 worker 配置后全部通过，未跳过测试。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 我已遵循仓库路由规则和开发协作规范。
- [x] 本次为构建配置调整；已执行配置解析、真实 Electron 启动 smoke 和完整现有测试。
- [x] 现有技术栈文档已经定义 Electron 启动事实，无需额外文档变更。
- [x] 我已运行要求的验证命令并如实报告失败。
- [x] 我已移除凭据、私有数据和敏感终端输出。