### PR TITLE
chore(release): prepare v0.1.14 preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cat > preview-release-notes.md <<'EOF'
+          > [!TIP]
+          > **下载安装包：请展开本页底部的 Assets，并选择与你的系统对应的文件。**
+          >
+          > macOS 下载 `.dmg`，Windows 下载 `.exe`，Linux 下载 `.AppImage` 或 `.deb`。
+
           ## Preview 安全提示
 
           这是公开测试用的 **Preview / Pre-release**，尚未使用正式开发者证书签名。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,14 @@ jobs:
 
           这是公开测试用的 **Preview / Pre-release**，尚未使用正式开发者证书签名。
 
-          - macOS：应用使用 ad-hoc 签名，未完成 Apple notarization，Gatekeeper 可能阻止首次打开。
+          - macOS：应用使用 ad-hoc 签名，未完成 Apple notarization，Gatekeeper 可能阻止首次打开。把 `CleanCode.app` 拖入 `/Applications`，确认安装包来源和校验值无误后，在终端运行：
+
+            ```bash
+            xattr -dr com.apple.quarantine /Applications/CleanCode.app
+            open /Applications/CleanCode.app
+            ```
+
+            命令只应作用于 `CleanCode.app`；请勿把目标路径替换为 `/Applications`、下载目录或用户目录。
           - Windows：安装程序未签名，SmartScreen 会显示“未知发布者”警告。
           - Linux：请使用 `SHA256SUMS.txt` 校验下载文件。
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",


### PR DESCRIPTION
## 改动摘要

- 将应用版本从 `0.1.13` 更新为 `0.1.14`。
- 在 Preview Release 顶部加入醒目的 `Assets` 下载入口提示，并说明各平台应选择的文件类型。
- 在 macOS 安全提示中加入仅针对 `CleanCode.app` 的 quarantine 移除与启动命令。
- 明确禁止把命令目标扩大到 `/Applications`、下载目录或用户目录。

## 背景与目标

为 v0.1.14 Preview 做发布准备，让用户能快速找到折叠在 Release 底部的安装包，并让下载 macOS 构建的用户在 Gatekeeper 阻止首次启动时可以直接看到与 README 一致的安全打开步骤。

## 影响范围

不涉及业务限界上下文或应用运行时行为。改动仅影响根包版本元数据，以及新建 GitHub Preview Release 时生成的说明文案；未修改构建、打包、上传或发布权限逻辑。

## 验证

- `package.json` 解析及版本值断言通过。
- Release workflow YAML 解析通过。
- `git diff --check` 通过。
- `pnpm pre-commit` 通过：静态质量门禁、400 个单元测试文件、41 个集成测试文件、23 个契约测试文件及 18 个 E2E 测试文件全部通过。

## 风险与限制

- 新提示只会进入新创建的 Release，不会自动回写已经发布的 v0.1.13。
- 应用仍使用 ad-hoc 签名且未 notarize；命令会绕过该应用的首次 Gatekeeper 检查，因此提示要求先核验来源和 SHA-256，并限制为精确应用路径。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 我已遵循仓库路由规则和开发协作规范。
- [x] 行为变化时，我已新增或更新最低有效层级的测试。
- [x] 稳定行为变化时，我已更新负责该事实的文档。
- [x] 我已运行要求的验证命令并如实报告失败。
- [x] 我已移除凭据、私有数据和敏感终端输出。