### PR TITLE
chore(release): prepare v0.1.15 preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",


### PR DESCRIPTION
## 改动摘要

- 将应用版本从 `0.1.14` 更新为 `0.1.15`。
- 为 `v0.1.15` Preview Release 准备与 tag 一致的包版本元数据。

## 影响范围

不涉及业务限界上下文、应用运行时行为、依赖、锁文件、构建配置或发布 workflow。

## 验证

- `package.json` 解析及版本值断言通过。
- `git diff --check` 通过。
- 按仓库对纯顶层版本号改动的明确例外，未运行 `pnpm pre-commit` 或 `pnpm build`。

## 风险与限制

- PR 合并后需从合并后的 `main` 创建 `v0.1.15` tag，才会触发三平台 Preview 发布。
- Preview 仍沿用现有未正式签名/公证的发布策略。

## 检查清单

- [x] 改动聚焦单一发布目标。
- [x] 版本、目标 tag 与发布 workflow 契约一致。
- [x] 未混入无关改动或敏感信息。