### PR TITLE
fix: 按需挂载快捷执行栏黑洞媒体，避免启动闪影

### DIFF
--- a/src/contexts/block-graph/presentation/components/QuickExecutionBar.tsx
+++ b/src/contexts/block-graph/presentation/components/QuickExecutionBar.tsx
@@ -107,6 +107,7 @@ export function QuickExecutionBar({
   const [isNearBlackHole, setIsNearBlackHole] = useState(false)
   const [clearAnimation, setClearAnimation] = useState<DragAnimation | null>(null)
   const [returnAnimation, setReturnAnimation] = useState<DragAnimation | null>(null)
+  const isBlackHoleVisible = draggedNumber !== null || clearAnimation !== null
   const completeClearAnimation = (motionId: string): void => {
     setClearAnimation((current) => (current?.motion.id === motionId ? null : current))
     if (blackHoleMotionRef.current) blackHoleMotionRef.current.playbackRate = 1
@@ -593,7 +594,7 @@ export function QuickExecutionBar({
         ref={blackHoleTargetRef}
         className={[
           'quick-execution__black-hole',
-          draggedNumber || clearAnimation ? 'quick-execution__black-hole--visible' : '',
+          isBlackHoleVisible ? 'quick-execution__black-hole--visible' : '',
           isClearTarget || clearAnimation ? 'quick-execution__black-hole--target' : '',
           clearAnimation ? 'quick-execution__black-hole--clearing' : ''
         ]
@@ -638,30 +639,33 @@ export function QuickExecutionBar({
             {t('quickExecution.releaseDropTarget', { number: draggedNumber })}
           </span>
         ) : null}
-        <span className="quick-execution__black-hole-visual" aria-hidden="true">
-          <img
-            className="quick-execution__black-hole-image"
-            data-quick-execution-black-hole
-            src={blackHoleAssetUrl}
-            alt=""
-            draggable={false}
-          />
-          <video
-            ref={blackHoleMotionRef}
-            className="quick-execution__black-hole-motion"
-            data-quick-execution-black-hole-motion
-            src={blackHoleMotionUrl}
-            poster={blackHoleAssetUrl}
-            autoPlay
-            loop
-            muted
-            playsInline
-            preload="auto"
-            onCanPlay={(event) => {
-              event.currentTarget.playbackRate = isClearTarget || clearAnimation ? 1.75 : 1
-            }}
-          />
-        </span>
+        {/* Keep hidden media out of the compositor during the bar's entrance. */}
+        {isBlackHoleVisible ? (
+          <span className="quick-execution__black-hole-visual" aria-hidden="true">
+            <img
+              className="quick-execution__black-hole-image"
+              data-quick-execution-black-hole
+              src={blackHoleAssetUrl}
+              alt=""
+              draggable={false}
+            />
+            <video
+              ref={blackHoleMotionRef}
+              className="quick-execution__black-hole-motion"
+              data-quick-execution-black-hole-motion
+              src={blackHoleMotionUrl}
+              poster={blackHoleAssetUrl}
+              autoPlay
+              loop
+              muted
+              playsInline
+              preload="auto"
+              onCanPlay={(event) => {
+                event.currentTarget.playbackRate = isClearTarget || clearAnimation ? 1.75 : 1
+              }}
+            />
+          </span>
+        ) : null}
       </div>
     </AnchoredSurfaceMotion>
   )

--- a/src/contexts/block-graph/presentation/styles/quick-execution.css
+++ b/src/contexts/block-graph/presentation/styles/quick-execution.css
@@ -35,10 +35,19 @@
   border: 1px solid var(--cc-border);
   border-radius: 8px;
   background: var(--cc-surface-translucent);
-  backdrop-filter: blur(10px);
   transition:
     border-color var(--cc-motion-duration-feedback) var(--cc-easing-standard),
     background var(--cc-motion-duration-feedback) var(--cc-easing-standard);
+}
+
+/*
+ * Do not promote the translucent slots while the bottom-control spring is
+ * entering or leaving. Chromium on Windows can paint an uninitialised
+ * backdrop surface as a black rectangle for one compositor frame while the
+ * parent is being transformed. The settled state keeps the intended blur.
+ */
+.quick-execution[data-surface-spring-state='open'] .quick-execution__slot {
+  backdrop-filter: blur(10px);
 }
 
 .quick-execution__slot--filled {

--- a/src/platform/electron-main/createMainWindow.ts
+++ b/src/platform/electron-main/createMainWindow.ts
@@ -92,15 +92,21 @@ export function createMainWindow(input: {
 
   if (startupState.displayMode === 'maximized') mainWindow.maximize()
 
-  if (input.policy.mode === 'offscreen-inactive') {
-    const { position } = input.policy
-    mainWindow.once('ready-to-show', () => {
-      if (mainWindow.isDestroyed()) return
+  mainWindow.once('ready-to-show', () => {
+    if (mainWindow.isDestroyed()) return
 
+    if (input.policy.mode === 'offscreen-inactive') {
+      const { position } = input.policy
       mainWindow.setPosition(position.x, position.y, false)
       mainWindow.showInactive()
-    })
-  }
+      return
+    }
+
+    // Do not expose an uninitialised renderer surface. On Windows the native
+    // window can otherwise present a stale/black compositor tile for one or
+    // more frames while React Flow restores the persisted canvas viewport.
+    mainWindow.show()
+  })
 
   const loadRenderer = () => {
     if (mainWindow.isDestroyed()) return

--- a/src/platform/electron-main/electronWindowPolicy.ts
+++ b/src/platform/electron-main/electronWindowPolicy.ts
@@ -1,7 +1,12 @@
 interface NormalElectronWindowPolicy {
   readonly backgroundThrottling: true
   readonly mode: 'normal'
-  readonly show: true
+  /**
+   * Keep the native window hidden until Electron has a first composited frame.
+   * Showing it immediately can expose an uninitialised renderer surface on
+   * Windows while the restored canvas is still being painted.
+   */
+  readonly show: false
 }
 
 interface OffscreenElectronWindowPolicy {
@@ -26,7 +31,7 @@ export function resolveElectronWindowPolicy(input: {
     return {
       backgroundThrottling: true,
       mode: 'normal',
-      show: true
+      show: false
     }
   }
 

--- a/tests/integration/platform/platform.window-policy.spec.ts
+++ b/tests/integration/platform/platform.window-policy.spec.ts
@@ -5,7 +5,7 @@ describe('Electron window policy', () => {
     const expectedPolicy = {
       backgroundThrottling: true,
       mode: 'normal',
-      show: true
+      show: false
     }
 
     expect(resolveElectronWindowPolicy({ backgroundE2eMarker: undefined })).toEqual(expectedPolicy)

--- a/tests/unit/contexts/block-graph/block-graph.quick-execution-bar.presentation.spec.tsx
+++ b/tests/unit/contexts/block-graph/block-graph.quick-execution-bar.presentation.spec.tsx
@@ -4,6 +4,29 @@ import type { BlockGraphSnapshot } from '../../../../src/contexts/block-graph/ap
 import { QuickExecutionBar } from '../../../../src/contexts/block-graph/presentation/components/QuickExecutionBar'
 
 describe('quick execution bar', () => {
+  it.each([false, true])(
+    'keeps hidden black-hole media unmounted after workspace restoration (external drop: %s)',
+    (isExternalDropTarget) => {
+      const props = {
+        graph: createGraph(),
+        isExternalDropTarget,
+        onAdd: vi.fn(),
+        onBind: vi.fn(),
+        onClear: vi.fn(),
+        onFocus: vi.fn(),
+        onReorder: vi.fn()
+      }
+      const { rerender } = render(<QuickExecutionBar {...props} />)
+
+      expectBlackHoleMediaAbsent()
+
+      rerender(<QuickExecutionBar {...props} open={false} />)
+      rerender(<QuickExecutionBar {...props} open />)
+
+      expectBlackHoleMediaAbsent()
+    }
+  )
+
   it('keeps the bottom surface inert through exit and reuses it when the handoff reverses', () => {
     const props = {
       graph: createGraph(),
@@ -201,6 +224,7 @@ describe('quick execution bar', () => {
     fireEvent.drop(destination)
 
     expect(onReorder).toHaveBeenCalledWith(2, 1)
+    expectBlackHoleMediaAbsent()
   })
 
   it('keeps only rebind in the filled-slot menu', () => {
@@ -254,7 +278,7 @@ describe('quick execution bar', () => {
     expect(screen.getByRole('dialog', { name: '快捷位操作' })).toBe(popover)
   })
 
-  it('clears a filled slot while its intact proxy springs into the black hole', () => {
+  it('clears a filled slot while its intact proxy springs into the black hole', async () => {
     const onClear = vi.fn()
     render(
       <QuickExecutionBar
@@ -369,6 +393,13 @@ describe('quick execution bar', () => {
       'quick-execution__black-hole--target',
       'quick-execution__black-hole--clearing'
     )
+    fireEvent.dragEnd(source)
+    expect(blackHole.querySelector('[data-quick-execution-black-hole-motion]')).toBe(
+      blackHoleMotion
+    )
+
+    await waitFor(() => expect(clearAnimation).not.toBeInTheDocument(), { timeout: 2_000 })
+    expectBlackHoleMediaAbsent()
   })
 
   it('starts returning the source slot when a black-hole drag is cancelled', () => {
@@ -393,6 +424,11 @@ describe('quick execution bar', () => {
     expect(screen.queryByRole('region', { name: '拖到此处清空快捷位 2' })).not.toBeInTheDocument()
     expect(source).toHaveClass('quick-execution__slot--dragging')
     expect(document.querySelector('[data-quick-execution-return-animation]')).toBeInTheDocument()
+    expectBlackHoleMediaAbsent()
+
+    fireEvent.dragStart(source)
+    expect(document.querySelector('[data-quick-execution-black-hole]')).toBeInTheDocument()
+    expect(document.querySelector('[data-quick-execution-black-hole-motion]')).toBeInTheDocument()
   })
 
   it('returns a cancelled drag proxy to its source without changing the binding', () => {
@@ -432,6 +468,7 @@ describe('quick execution bar', () => {
 
     expect(onClear).not.toHaveBeenCalled()
     expect(onReorder).not.toHaveBeenCalled()
+    expectBlackHoleMediaAbsent()
     expect(document.querySelector('[data-quick-execution-drag-proxy]')).not.toBeInTheDocument()
     expect(source).toHaveClass('quick-execution__slot--dragging')
     expect(document.querySelector('[data-quick-execution-trash]')).toHaveAttribute(
@@ -477,6 +514,12 @@ describe('quick execution bar', () => {
     }
   })
 })
+
+function expectBlackHoleMediaAbsent(): void {
+  const blackHole = document.querySelector<HTMLElement>('[data-quick-execution-trash]')!
+  expect(blackHole).toHaveAttribute('aria-hidden', 'true')
+  expect(blackHole.querySelector('img, video')).not.toBeInTheDocument()
+}
 
 function createGraph(): BlockGraphSnapshot {
   return {

--- a/tests/unit/presentation/surface-motion-styles.spec.ts
+++ b/tests/unit/presentation/surface-motion-styles.spec.ts
@@ -100,6 +100,17 @@ describe('surface motion styles', () => {
       expect(rule).toContain('will-change: transform')
     }
   )
+
+  it('defers quick execution backdrop filtering until the bottom spring settles', () => {
+    const slotRule = readRule(quickExecutionStyles, '.quick-execution__slot')
+    const settledRule = readRule(
+      quickExecutionStyles,
+      ".quick-execution[data-surface-spring-state='open'] .quick-execution__slot"
+    )
+
+    expect(slotRule).not.toContain('backdrop-filter')
+    expect(settledRule).toContain('backdrop-filter: blur(10px)')
+  })
 })
 
 function readRule(styles: string, selector: string): string {


### PR DESCRIPTION
## 改动摘要

快捷执行栏的黑洞 PNG/WebM 仅在内部快捷位拖拽或清除动画期间挂载，隐藏时卸载。媒体挂载与可见样式复用同一个状态条件，清除动画期间保留同一个视频节点。

## 背景与目标

Windows 启动并恢复已有工作区时，画布底部偶发黑影。排查发现，快捷执行栏进入动画期间，透明的黑洞容器仍挂载自动播放、预加载的 WebM。此改动避免隐藏媒体参与快捷栏首次进入时的合成，消除该可疑触发条件。

## 影响范围

仅修改 BlockGraph 表现层的 QuickExecutionBar 及其组件测试。可见性由现有拖拽和清除动画状态派生，绑定事实继续由 BlockGraph 拥有；没有新增状态 owner、跨层依赖或持久化变更。稳定产品语义未改变，无需更新事实文档。

## 验证

- TDD：新增及扩展断言在修复前产生 6 处预期失败，修复后组件测试 16/16 通过。
- 覆盖已有工作区挂载、外部拖入提示、快捷栏关闭再打开、排序、取消、无效投放、再次拖拽，以及清除动画期间保留视频、完成后卸载媒体。
- `pnpm pre-commit` 通过：全部静态检查、135 项 contract、2,548 项 unit、489 项当前平台 integration、7 项 Electron smoke；21 项平台专属 integration 按配置跳过。
- `CLEANCODE_E2E_PREBUILT=1 pnpm exec vitest run --config vitest.e2e.config.ts --no-file-parallelism tests/e2e/quick-execution.e2e.spec.ts` 通过，复用同一内容的构建产物验证真实拖拽、视频播放及快捷执行流程。
- `git diff --check` 通过。

## 风险与限制

本地验证环境为 macOS。组件测试证明媒体挂载条件，现有 Electron E2E 证明交互和视频播放；Windows 启动首帧闪影是否消失仍需原生复测，GPU 合成时序是排查推断，尚未确证。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 我已遵循仓库路由规则和开发协作规范。
- [x] 行为变化时，我已新增或更新最低有效层级的测试。
- [x] 稳定行为变化时，我已更新负责该事实的文档。（本次稳定语义未变，无需更新。）
- [x] 我已运行要求的验证命令并如实报告失败。
- [x] 我已移除凭据、私有数据和敏感终端输出。
