### PR TITLE
chore(release): prepare v0.1.16 preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cleancode",
   "productName": "CleanCode",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "author": "chen-985211",
   "homepage": "https://github.com/chen-985211/cleancode",

--- a/tests/e2e/agent-codex-session.e2e.spec.ts
+++ b/tests/e2e/agent-codex-session.e2e.spec.ts
@@ -27,7 +27,8 @@ import {
   waitForAgentProviderInstalled,
   waitForAgentTerminalReady,
   stopAgentLaunchForShellSetup,
-  writeAgentTerminalInput
+  writeAgentTerminalInput,
+  type AgentLaunchReadySnapshot
 } from '../support/e2eAgentRuntime'
 import { selectAgentProviderFromCreateMenu } from '../support/e2eCanvasMenu'
 import { pollUntilState } from '../support/e2ePolling'
@@ -118,14 +119,10 @@ describe('Codex Agent session e2e', () => {
     'keeps the Agent WebGL surface visible while raising its backing density',
     async () => {
       await expectDesktopRuntime(page)
-      const launchReady = waitForAgentLaunchReady(page)
       await page.getByRole('button', { name: '添加项目' }).click()
       await waitForAgentCount(page, 0)
       await waitForAgentProviderInstalled(page, 'codex')
-      await selectAgentProviderFromCreateMenu(page, 'Codex')
-      await waitForAgentCount(page, 1)
-      await waitForAgentTerminals(page, 1)
-      await launchReady
+      await createCodexAgentAndWaitForLaunch(page)
 
       const terminal = page.locator('[data-agent-console-node] .agent-terminal-viewport').first()
       await stopAgentLaunchForShellSetup(page, terminal)
@@ -217,14 +214,10 @@ describe('Codex Agent session e2e', () => {
     'restores a Codex session selected through /resume even when no later turn completes',
     async () => {
       await expectDesktopRuntime(page)
-      const firstLaunchReady = waitForAgentLaunchReady(page)
       await page.getByRole('button', { name: '添加项目' }).click()
       await waitForAgentCount(page, 0)
       await waitForAgentProviderInstalled(page, 'codex')
-      await selectAgentProviderFromCreateMenu(page, 'Codex')
-      await waitForAgentCount(page, 1)
-      await waitForAgentTerminals(page, 1)
-      const firstLaunchRuntime = await firstLaunchReady
+      const firstLaunchRuntime = await createCodexAgentAndWaitForLaunch(page)
 
       const firstLaunch = await waitForCodexLaunch(
         fakeCodex.reportPath,
@@ -405,6 +398,21 @@ async function waitForCodexResumeSelection(reportPath: string, sessionId: string
       reports.find((report) => report.kind === 'resume' && report.sessionId === sessionId),
     `Codex /resume selection ${sessionId}`
   )
+}
+
+async function createCodexAgentAndWaitForLaunch(page: Page): Promise<AgentLaunchReadySnapshot> {
+  await page.getByRole('button', { name: '选择默认 Agent' }).click()
+  const providerOption = page
+    .getByRole('menu', { name: '选择默认 Agent' })
+    .getByRole('menuitemradio', { name: 'Codex', exact: true })
+  await providerOption.waitFor({ state: 'visible' })
+
+  // Provider discovery and menu preparation must not consume the launch deadline.
+  const launchReady = waitForAgentLaunchReady(page)
+  await providerOption.click()
+  await waitForAgentCount(page, 1)
+  await waitForAgentTerminals(page, 1)
+  return launchReady
 }
 
 async function waitForCodexSessionEnd(reportPath: string, sessionId: string): Promise<void> {

--- a/tests/fixtures/contexts/agent/fakeCodexCli.ts
+++ b/tests/fixtures/contexts/agent/fakeCodexCli.ts
@@ -95,10 +95,14 @@ export async function readFakeCodexCliReports(
   try {
     const contents = await readFile(reportPath, 'utf8')
 
-    return contents
-      .split('\n')
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as FakeCodexCliReport)
+    return (
+      contents
+        .split('\n')
+        // A concurrent append may expose the final record before its newline is written.
+        .slice(0, -1)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as FakeCodexCliReport)
+    )
   } catch (error) {
     if (isMissingFileError(error)) {
       return []

--- a/tests/unit/contexts/agent/agent.fake-codex-cli-reports.spec.ts
+++ b/tests/unit/contexts/agent/agent.fake-codex-cli-reports.spec.ts
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises'
+import type * as fsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFakeCodexCliReports } from '../../../fixtures/contexts/agent/fakeCodexCli'
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof fsPromises>()),
+  readFile: vi.fn()
+}))
+
+const reportPath = join('fixture', 'reports.jsonl')
+const report = { args: [], cwd: 'workspace', kind: 'inspection', pid: 123 }
+const nextReport = { ...report, kind: 'color-query-response' }
+
+describe('fake Codex CLI reports', () => {
+  beforeEach(() => {
+    vi.mocked(readFile).mockReset()
+  })
+
+  it.each([
+    ['partial JSON', '{"kind":"color-query-res'],
+    ['JSON awaiting its newline', JSON.stringify(nextReport)]
+  ])('waits for the record delimiter when an append exposes %s', async (_name, tail) => {
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(`${JSON.stringify(report)}\n${tail}`)
+      .mockResolvedValueOnce(`${JSON.stringify(report)}\n${JSON.stringify(nextReport)}\n`)
+
+    await expect(readFakeCodexCliReports(reportPath)).resolves.toEqual([report])
+    await expect(readFakeCodexCliReports(reportPath)).resolves.toEqual([report, nextReport])
+  })
+
+  it.each(['', '{"kind":"inspection', JSON.stringify(report)])(
+    'returns no reports before the first complete record: %j',
+    async (contents) => {
+      vi.mocked(readFile).mockResolvedValue(contents)
+
+      await expect(readFakeCodexCliReports(reportPath)).resolves.toEqual([])
+    }
+  )
+
+  it('does not hide a malformed completed record', async () => {
+    vi.mocked(readFile).mockResolvedValue(`${JSON.stringify(report)}\n{"kind":\n`)
+
+    await expect(readFakeCodexCliReports(reportPath)).rejects.toBeInstanceOf(SyntaxError)
+  })
+
+  it('returns no reports until the report file exists', async () => {
+    vi.mocked(readFile).mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    await expect(readFakeCodexCliReports(reportPath)).resolves.toEqual([])
+  })
+
+  it('preserves file read failures', async () => {
+    const error = Object.assign(new Error('denied'), { code: 'EACCES' })
+    vi.mocked(readFile).mockRejectedValue(error)
+
+    await expect(readFakeCodexCliReports(reportPath)).rejects.toBe(error)
+  })
+})


### PR DESCRIPTION
## 改动摘要

将应用版本从 0.1.15 更新为 0.1.16，并修复发布验收中暴露的两处测试竞态。

## 背景与目标

准备 v0.1.16 Preview 发布。首轮 Linux E2E 在读取尚未写完的 fake Codex JSONL 报告时解析失败；Windows 的两个 Codex 场景把项目和 Provider 菜单准备计入启动期限，trace 显示约 10 秒被启动前的菜单准备消耗。

## 影响范围

仅涉及 package.json 顶层版本及 tests 层，不修改生产代码或业务限界上下文。版本以 package.json 为事实来源，现有 release.yml 负责发布。

fake Codex 报告读取器只返回以换行结束的完整记录，写入中的尾记录留待后续观察；完整但损坏的记录和文件访问错误仍然抛出。两个 Codex E2E 在菜单选项就绪后、实际创建 Agent 前订阅运行时事件并开始原有 15 秒期限。

## 验证

- 8 个报告读取回归用例覆盖完整/未完成记录、后续追加、缺失文件、损坏记录和访问失败；修复前 4 个失败，修复后全部通过。
- JSON 解析与 0.1.16 版本断言通过。
- pnpm verify:full 通过：全部静态门禁、135 个 contract、2557 个 unit、489 个 integration 和全部 52 个 Electron E2E；integration 的 21 个跳过项来自现有平台条件。三平台 CI 全部通过：Full cross-platform quality（33972392176）与 Electron E2E（33972392276），包括三平台构建、九个 E2E 分片和 Windows packaged smoke。
- git diff --check 通过。

报告边界下沉到 unit；现有 E2E 继续证明真实 xterm 渲染与 Electron、PTY、IPC、持久化组合下的会话恢复主路径。未提高 timeout、添加 retry 或削弱产品断言。

## 风险与限制

合并后从对应 main 提交创建 v0.1.16 标签。发布继续遵循现有 Preview 策略，不标记 Latest；macOS 使用 ad-hoc 签名且未公证，Windows 安装包未签名。首轮 CI 失败保留在 Actions 历史中。

## 检查清单

- [x] 改动聚焦 0.1.16 发布及其验收阻塞。
- [x] 已遵循仓库路由规则和开发协作规范。
- [x] 测试支撑修复已补最低有效层级回归。
- [x] 无稳定产品规则变化，无需更新规则文档。
- [x] 已保留并说明首轮失败证据。
- [x] 未引入凭据、私有数据或敏感终端输出。
