### PR TITLE
fix(project): 修复 worktree 菜单切换并补齐展开收回动效

### DIFF
--- a/src/contexts/project/presentation/components/WorkspaceRowMenu.tsx
+++ b/src/contexts/project/presentation/components/WorkspaceRowMenu.tsx
@@ -116,14 +116,12 @@ export function WorkspaceRowMenu({
           aria-haspopup="menu"
           aria-expanded={isOpen}
           onClick={() => {
-            setMenuPosition(null)
             pendingInitialFocusRef.current = !isOpen
             onToggle()
           }}
           onKeyDown={(event) => {
             if (isOpen || !['ArrowDown', 'ArrowUp'].includes(event.key)) return
             event.preventDefault()
-            setMenuPosition(null)
             pendingInitialFocusRef.current = true
             onToggle()
           }}
@@ -133,6 +131,8 @@ export function WorkspaceRowMenu({
       </TooltipLabel>
       <AnchoredSurfaceMotion
         open={isOpen}
+        springPreset="anchored"
+        onExitComplete={() => setMenuPosition(null)}
         portalContainer={document.body}
         id={menuId}
         className="workspace-row-menu anchored-surface-motion"
@@ -140,7 +140,11 @@ export function WorkspaceRowMenu({
         aria-labelledby={triggerId}
         data-side={menuPosition?.side ?? 'bottom'}
         onBlur={(event) => {
-          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          const nextTarget = event.relatedTarget as Node | null
+          if (
+            !event.currentTarget.contains(nextTarget) &&
+            !triggerRef.current?.contains(nextTarget)
+          ) {
             onClose()
           }
         }}

--- a/src/presentation/shared/motion/surfaceSpringMotion.ts
+++ b/src/presentation/shared/motion/surfaceSpringMotion.ts
@@ -5,6 +5,7 @@ import {
 } from './springProgressMotion'
 
 export type SurfaceSpringPreset =
+  | 'anchored'
   | 'anchored-bottom-left'
   | 'anchored-top-right'
   | 'bottom-control'
@@ -46,6 +47,7 @@ export function createSurfaceSpringMotionController({
   const controller = createSpringProgressMotionController({
     clear: clearPresentation,
     dynamics: { dampingRatio: 1, response: responseForPreset(preset) },
+    retargetPolicy: preset === 'anchored' ? 'preserve' : 'toward-target-only',
     scheduler,
     settlementThresholds: preset === 'bottom-control' ? { speed: 0.25, value: 0.007 } : undefined,
     stateAttribute
@@ -77,6 +79,15 @@ function presentSurface(
 }
 
 function resolvePresentation(preset: SurfaceSpringPreset, remaining: number) {
+  if (preset === 'anchored') {
+    return {
+      contentOpacity: 1,
+      opacity: 1 - remaining,
+      scale: 1 - 0.16 * remaining,
+      translateX: `calc(var(--cc-anchored-surface-offset-x) * ${round(remaining)})`,
+      translateY: `calc(var(--cc-anchored-surface-offset-y) * ${round(remaining)})`
+    }
+  }
   if (preset === 'anchored-bottom-left') {
     return {
       contentOpacity: 1,
@@ -123,6 +134,7 @@ function resolvePresentation(preset: SurfaceSpringPreset, remaining: number) {
 }
 
 function responseForPreset(preset: SurfaceSpringPreset): number {
+  if (preset === 'anchored') return 0.28
   if (preset === 'anchored-bottom-left') return 0.18
   if (preset === 'anchored-top-right') return 0.24
   if (preset === 'bottom-control') return 0.16

--- a/tests/unit/contexts/project/workspace-row-menu.presentation.spec.tsx
+++ b/tests/unit/contexts/project/workspace-row-menu.presentation.spec.tsx
@@ -1,0 +1,266 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { ProjectSidebar } from '../../../../src/contexts/project/presentation/components/ProjectSidebar'
+import { createWorkbenchSnapshot } from '../../../fixtures/presentation/appShellFixtures'
+
+describe('workspace row menu interaction', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  describe.each([true, false])('when the worktree is current: %s', (isCurrent) => {
+    it.each(['pointer', 'ArrowDown', 'ArrowUp'] as const)(
+      'closes on a second trigger click and reopens after opening with %s',
+      (openingInput) => {
+        const { trigger, onSelectWorkspace, onArchiveBranchWorkspace } = renderSidebar(isCurrent)
+
+        if (openingInput === 'pointer') {
+          clickWithFocus(trigger)
+        } else {
+          act(() => trigger.focus())
+          fireEvent.keyDown(trigger, { key: openingInput })
+        }
+
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+        expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+
+        clickWithFocus(trigger)
+
+        expectMenuClosed(trigger)
+        expect(trigger).toHaveFocus()
+
+        clickWithFocus(trigger)
+
+        expect(trigger).toHaveAttribute('aria-expanded', 'true')
+        expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+        expect(onSelectWorkspace).not.toHaveBeenCalled()
+        expect(onArchiveBranchWorkspace).not.toHaveBeenCalled()
+      }
+    )
+  })
+
+  it.each(['outside focus', 'lost focus', 'Escape', 'outside pointer'] as const)(
+    'still dismisses the menu on %s',
+    (dismissal) => {
+      const { trigger } = renderSidebar(true)
+      clickWithFocus(trigger)
+      const archive = screen.getByRole('menuitem', { name: '归档工作区' })
+
+      switch (dismissal) {
+        case 'outside focus':
+          act(() => screen.getByRole('button', { name: '添加项目' }).focus())
+          break
+        case 'lost focus':
+          act(() => archive.blur())
+          break
+        case 'Escape':
+          fireEvent.keyDown(archive, { key: 'Escape' })
+          break
+        case 'outside pointer':
+          fireEvent.pointerDown(document.body)
+          fireEvent.pointerUp(document.body)
+          fireEvent.click(document.body)
+          break
+      }
+
+      expectMenuClosed(trigger)
+      if (dismissal === 'Escape' || dismissal === 'outside pointer') {
+        expect(trigger).toHaveFocus()
+      }
+    }
+  )
+
+  it.each(['bottom', 'top'] as const)(
+    'preserves the live menu and its motion when reversing below or above the trigger: %s',
+    (side) => {
+      const frames = installMotionFrames()
+      vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+        this: HTMLElement
+      ) {
+        return this.getAttribute('aria-label') === '打开 feat 工作区菜单'
+          ? new DOMRect(174, side === 'top' ? window.innerHeight - 32 : 100, 28, 28)
+          : new DOMRect()
+      })
+      vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(80)
+      const { trigger } = renderSidebar(true)
+      clickWithFocus(trigger)
+      const menu = screen.getByRole('menu')
+      const position = { left: menu.style.left, top: menu.style.top }
+
+      expect(menu).toHaveAttribute('data-side', side)
+      frames.advance(40)
+      const openingOpacity = readOpacity(menu)
+      expect(openingOpacity).toBeGreaterThan(0)
+      expect(openingOpacity).toBeLessThan(1)
+
+      clickWithFocus(trigger)
+
+      expectMenuClosed(trigger)
+      expect(menu).toHaveAttribute('inert')
+      expect(menu).toHaveStyle({ ...position, visibility: 'visible' })
+      expect(readOpacity(menu)).toBe(openingOpacity)
+      // The old velocity is carried through the reversal before the spring turns back.
+      frames.advance(1)
+      expect(readOpacity(menu)).toBeGreaterThan(openingOpacity)
+      frames.advance(80)
+      const closingOpacity = readOpacity(menu)
+      expect(closingOpacity).toBeGreaterThan(0)
+      expect(closingOpacity).toBeLessThan(openingOpacity)
+
+      clickWithFocus(trigger)
+
+      expect(screen.getByRole('menu')).toBe(menu)
+      expect(menu).not.toHaveAttribute('inert')
+      expect(menu).toHaveStyle({ ...position, visibility: 'visible' })
+      expect(readOpacity(menu)).toBe(closingOpacity)
+      frames.advance(1)
+      expect(readOpacity(menu)).toBeLessThan(closingOpacity)
+      frames.finish()
+      expect(screen.getByRole('menu')).toBe(menu)
+      expect(readOpacity(menu)).toBe(1)
+      expect(menu).toHaveAttribute('data-surface-motion-state', 'open')
+      expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+
+      clickWithFocus(trigger)
+      expect(menu).toHaveStyle({ ...position, visibility: 'visible' })
+      frames.finish()
+      expect(menu).not.toBeInTheDocument()
+      expectMenuClosed(trigger)
+    }
+  )
+
+  it.each([2, 3, 6, 7])('settles at the latest intent after %s rapid clicks', (clickCount) => {
+    const frames = installMotionFrames()
+    const { trigger } = renderSidebar(true)
+    for (let click = 0; click < clickCount; click += 1) {
+      clickWithFocus(trigger)
+      frames.advance(16)
+    }
+
+    frames.finish()
+
+    if (clickCount % 2 === 0) {
+      expectMenuClosed(trigger)
+      expect(document.querySelector('.workspace-row-menu')).toBeNull()
+    } else {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true')
+      expect(readOpacity(screen.getByRole('menu'))).toBe(1)
+      expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+    }
+  })
+
+  it('toggles immediately and restores menu focus when motion is reduced', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: () => true
+    }))
+    const { trigger } = renderSidebar(true)
+    clickWithFocus(trigger)
+    expect(readOpacity(screen.getByRole('menu'))).toBe(1)
+    expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+
+    clickWithFocus(trigger)
+    expectMenuClosed(trigger)
+    expect(document.querySelector('.workspace-row-menu')).toBeNull()
+
+    clickWithFocus(trigger)
+    expect(readOpacity(screen.getByRole('menu'))).toBe(1)
+    expect(screen.getByRole('menuitem', { name: '归档工作区' })).toHaveFocus()
+  })
+})
+
+function readOpacity(menu: HTMLElement): number {
+  return Number.parseFloat(menu.style.getPropertyValue('--cc-surface-motion-opacity'))
+}
+
+function installMotionFrames() {
+  let now = 0
+  let nextId = 0
+  const callbacks = new Map<number, FrameRequestCallback>()
+  vi.spyOn(window.performance, 'now').mockImplementation(() => now)
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    callbacks.set(++nextId, callback)
+    return nextId
+  })
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => callbacks.delete(id))
+  const advance = (milliseconds: number): void => {
+    now += milliseconds
+    const pending = [...callbacks.values()]
+    callbacks.clear()
+    act(() => pending.forEach((callback) => callback(now)))
+  }
+  return {
+    advance,
+    finish: (): void => {
+      for (let frame = 0; callbacks.size > 0 && frame < 240; frame += 1) advance(1000 / 120)
+      expect(callbacks.size).toBe(0)
+    }
+  }
+}
+
+function expectMenuClosed(trigger: HTMLElement): void {
+  expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+}
+
+function clickWithFocus(target: HTMLElement): void {
+  fireEvent.pointerDown(target)
+  fireEvent.mouseDown(target)
+  // fireEvent.click alone omits the focus transfer that precedes a browser click.
+  act(() => target.focus())
+  fireEvent.pointerUp(target)
+  fireEvent.mouseUp(target)
+  fireEvent.click(target)
+}
+
+function renderSidebar(isCurrent: boolean) {
+  const workbench = createWorkbenchSnapshot('/tmp/alpha-project', 'alpha-project', {
+    workspaces: [
+      {
+        workspaceId: 'main',
+        workspaceKind: 'default',
+        displayName: 'main',
+        directory: '/tmp/alpha-project',
+        gitBranch: 'main',
+        isCurrent: !isCurrent
+      },
+      {
+        workspaceId: 'feature',
+        workspaceKind: 'linked-worktree',
+        displayName: 'feat',
+        directory: '/tmp/alpha-project-feature',
+        gitBranch: 'feat',
+        isCurrent
+      }
+    ]
+  })
+  const onSelectWorkspace = vi.fn()
+  const onArchiveBranchWorkspace = vi.fn()
+  render(
+    <ProjectSidebar
+      workbenches={[workbench]}
+      currentWorkbench={workbench}
+      isDesktopRuntime
+      onAddProject={vi.fn()}
+      onArchiveBranchWorkspace={onArchiveBranchWorkspace}
+      onCheckoutMainBranch={vi.fn()}
+      onCreateBranchWorkspace={vi.fn()}
+      onRemoveProject={vi.fn()}
+      onReorderProject={vi.fn()}
+      onSelectWorkspace={onSelectWorkspace}
+    />
+  )
+
+  return {
+    onArchiveBranchWorkspace,
+    onSelectWorkspace,
+    trigger: screen.getByRole('button', { name: '打开 feat 工作区菜单' })
+  }
+}

--- a/tests/unit/presentation/shared/surface-spring-motion.spec.ts
+++ b/tests/unit/presentation/shared/surface-spring-motion.spec.ts
@@ -5,6 +5,92 @@ import {
 import type { SpringProgressMotionFrameScheduler } from '../../../../src/presentation/shared/motion/springProgressMotion'
 
 describe('surface spring motion', () => {
+  it.each([true, false])(
+    'keeps an anchored surface visibly between its compact and full size during the transition: visible=%s',
+    (visible) => {
+      const scheduler = createFrameScheduler()
+      const root = createRoot()
+      const controller = createSurfaceSpringMotionController({ preset: 'anchored', scheduler })
+      const settled = vi.fn()
+      controller.intentChanged(root, {
+        onSettled: settled,
+        reducedMotion: false,
+        visible: true
+      })
+      const compactScale = readNumber(root, '--cc-surface-motion-scale')
+      expect.soft(compactScale).toBeGreaterThanOrEqual(0.7)
+      expect.soft(compactScale).toBeLessThan(0.9)
+      if (!visible) {
+        scheduler.advanceUntilIdle()
+        settled.mockClear()
+        controller.intentChanged(root, {
+          onSettled: settled,
+          reducedMotion: false,
+          visible: false
+        })
+      }
+
+      scheduler.advanceNextFrame(100)
+
+      const opacity = readNumber(root, '--cc-surface-motion-opacity')
+      const scale = readNumber(root, '--cc-surface-motion-scale')
+      expect.soft(opacity).toBeGreaterThan(0.2)
+      expect.soft(opacity).toBeLessThan(0.8)
+      expect.soft(scale).toBeGreaterThan(compactScale)
+      expect.soft(scale).toBeLessThan(0.97)
+      expect(settled).not.toHaveBeenCalled()
+
+      scheduler.advanceUntilIdle()
+      expect(readNumber(root, '--cc-surface-motion-opacity')).toBe(visible ? 1 : 0)
+      expect(readNumber(root, '--cc-surface-motion-scale')).toBe(visible ? 1 : compactScale)
+      expect(settled).toHaveBeenCalledOnce()
+    }
+  )
+
+  it.each([false, true])(
+    'carries an anchored surface position and velocity into the new visible intent: %s',
+    (visible) => {
+      const scheduler = createFrameScheduler()
+      const root = createRoot()
+      const obsoleteSettled = vi.fn()
+      const settled = vi.fn()
+      const controller = createSurfaceSpringMotionController({ preset: 'anchored', scheduler })
+      controller.intentChanged(root, {
+        onSettled: obsoleteSettled,
+        reducedMotion: false,
+        visible: true
+      })
+      if (visible) {
+        scheduler.advanceUntilIdle()
+        obsoleteSettled.mockClear()
+        controller.intentChanged(root, {
+          onSettled: obsoleteSettled,
+          reducedMotion: false,
+          visible: false
+        })
+      }
+      scheduler.advanceNextFrame(40)
+      const previousOpacity = readNumber(root, '--cc-surface-motion-opacity')
+      scheduler.advanceNextFrame(1)
+      const currentOpacity = readNumber(root, '--cc-surface-motion-opacity')
+      const velocityBefore = currentOpacity - previousOpacity
+      const presentation = new Map(root.properties)
+
+      controller.intentChanged(root, { onSettled: settled, reducedMotion: false, visible })
+
+      expect(root.properties).toEqual(presentation)
+      scheduler.advanceNextFrame(1)
+      const velocityAfter = readNumber(root, '--cc-surface-motion-opacity') - currentOpacity
+      expect(Math.sign(velocityAfter)).toBe(Math.sign(velocityBefore))
+      expect(Math.abs(velocityAfter - velocityBefore)).toBeLessThan(Math.abs(velocityBefore) * 0.15)
+
+      scheduler.advanceUntilIdle()
+      expect(readNumber(root, '--cc-surface-motion-opacity')).toBe(visible ? 1 : 0)
+      expect(obsoleteSettled).not.toHaveBeenCalled()
+      expect(settled).toHaveBeenCalledOnce()
+    }
+  )
+
   it.each([
     ['anchored-bottom-left', '--cc-surface-motion-translate-y', 1],
     ['anchored-top-right', '--cc-surface-motion-translate-x', 1],


### PR DESCRIPTION
## 改动摘要

修复侧边栏 Git worktree 菜单再次点击触发按钮后重新打开的问题，让连续点击按顺序展开、关闭，并为展开和收回提供清楚可见、可中途反向的过渡。

- 焦点返回触发按钮时保留菜单状态，避免 blur 先关闭、click 随后重新打开。
- 保留菜单的位置和 live surface，退出动画完成后再清理；关闭意图立即停止交互。
- 复用共享弹簧动效，新增锚定菜单预设：从紧凑尺寸展开，反向时承接当前位置与速度，最后一次点击决定最终状态。

## 背景与目标

用户连续点击 worktree 的“更多”按钮时，预期第一次展开、第二次关闭。原实现存在焦点事件竞态，且切换时清空定位会直接隐藏退出中的菜单；原过渡幅度和节奏也使展开过程难以感知。

本次恢复一致的切换行为，并让菜单沿触发按钮附近的同一路径展开和收回。

## 影响范围

- Project 的 Presentation：`WorkspaceRowMenu` 修复焦点边界及定位清理时机；逻辑开关仍由 `ProjectCard` 拥有。
- 共享 Presentation：`surfaceSpringMotion` 提供锚定菜单的空间投影与反向策略，继续复用现有 presence 和逐帧生命周期。
- 不涉及领域状态、Git 操作、IPC、持久化或依赖变更。

## 验证

- 按 TDD 补充失败回归后修复，覆盖当前/非当前工作区、鼠标/键盘打开、再次点击关闭、外部关闭、上下锚点、快速连续切换、位置与速度连续、可见过渡中间态及 reduced motion。
- 4 个相关测试文件共 41 项通过。
- `env -u ELECTRON_RUN_AS_NODE pnpm pre-commit` 通过：静态检查、135 项 contract、2578 项 unit、489 项 integration、7 项 Electron smoke；平台及 smoke 范围外用例按配置跳过。
- `git diff --check` 通过。
- 已在现有 Electron 桌面窗口验证打开、关闭、重新打开和快速双击的最终状态。

## 风险与限制

- 最后一次展开幅度与节奏调整按用户要求通过代码和自动化测试验证，未再次做目视验收；测试不替代主观观感判断。
- 早期验证曾出现一项 PTY 退出清理超时；对应 3 个场景单独复查及后续完整门禁均通过，本 PR 未修改 PTY 实现。
- 本地验证平台为 macOS，其他平台由 PR CI 验证。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 已遵循仓库路由规则和开发协作规范。
- [x] 已新增或更新最低有效层级的行为测试。
- [x] 已核对 UI 契约与动效规范；本次恢复既有交互，动效参数属于实现细节，无需更新稳定产品语义文档。
- [x] 已运行要求的验证命令并如实报告失败。
- [x] 提交内容未包含凭据、私有数据或敏感终端输出。
