### PR TITLE
docs: 将多 Agent 协作演示置于 README 视频首位

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
 
 <p align="center"><sub>Coding Agents, terminal tasks, long-running services, and real dependency connections in one branch workspace.</sub></p>
 
+<p align="center"><strong>▶ Multi-Agent Collaboration Demo (0:39)</strong></p>
+
+https://github.com/user-attachments/assets/9e157258-5604-4da6-83f9-65943c19efc5
+
 <p align="center"><strong>▶ Full demo (2:33, with sound)</strong></p>
 
 https://github.com/user-attachments/assets/cafe373f-97b7-4f8c-b4a4-dfbc88ab26c3

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -31,6 +31,10 @@
 
 <p align="center"><sub>同一分支工作区中的 Coding Agent、终端任务、长驻服务与真实依赖连线。</sub></p>
 
+<p align="center"><strong>▶ 多 Agent 协作演示（0:39）</strong></p>
+
+https://github.com/user-attachments/assets/9e157258-5604-4da6-83f9-65943c19efc5
+
 <p align="center"><strong>▶ 完整演示（2:33，含声音）</strong></p>
 
 https://github.com/user-attachments/assets/cafe373f-97b7-4f8c-b4a4-dfbc88ab26c3


### PR DESCRIPTION
## 改动摘要

在中英文 README 的视频区域首位加入 39 秒的多 Agent 协作演示，原有 2 分 33 秒完整演示紧接其后。

## 背景与目标

让访问者先看到 Claude 创建 Codex 并委托其分析项目的简短演示，再观看完整产品演示。演示素材见 #97。

## 影响范围

仅修改 `README.md` 和 `README_ZH.md`，共新增 8 行；属于 docs 层，不改变业务上下文、生产代码或运行时行为。视频链接使用维护者提供的 GitHub 附件地址。

## 验证

- `pnpm check:docs` 通过。
- `pnpm exec prettier --check README.md README_ZH.md` 通过。
- `git diff --check` 与提交前 `git diff --cached --check` 通过。
- 已核对两种语言的视频顺序和 PR 差异，仅包含本次 README 改动。

文档和格式检查复用同一份未变化内容的通过结果；纯文档修改无需代码测试。

## 风险与限制

视频由 GitHub 附件托管，本地文档检查不验证线上播放器；附件 HEAD 检查返回 504，尚未确认远程播放状态。无运行时或迁移风险。

## 检查清单

- [x] 本次改动聚焦单一目标，没有混入无关清理。
- [x] 已遵循仓库路由规则和开发协作规范。
- [x] 已运行适用的文档和格式验证，并如实报告外链检查限制。
- [x] 本次新增文本未包含凭据或敏感终端输出。
- 行为测试与稳定行为文档更新：不适用，未修改生产行为。
